### PR TITLE
docs: 한국어 문서 번역 (1차 및 2차)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,128 +1,79 @@
-# Contributor Covenant Code of Conduct
+# 기여자 약속 행동 강령
 
-## Our Pledge
+## 우리의 약속
 
-We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+우리 구성원, 기여자, 리더는 연령, 신체 크기, 보이는 또는 보이지 않는 장애, 민족성, 성적 특징, 성 정체성 및 표현, 경험 수준, 교육, 사회경제적 지위, 국적, 외모, 인종, 종교 또는 성적 정체성 및 지향에 관계없이 모든 사람에게 괴롭힘 없는 커뮤니티 참여 경험을 제공할 것을 약속합니다.
 
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+우리는 개방적이고 환영하며 다양하고 포용적이며 건강한 커뮤니티에 기여하는 방식으로 행동하고 상호 작용할 것을 약속합니다.
 
-## Our Standards
+## 우리의 기준
 
-Examples of behavior that contributes to a positive environment for our
-community include:
+우리 커뮤니티에 긍정적인 환경을 조성하는 행동의 예는 다음과 같습니다.
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
-  and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
-  overall community
+* 다른 사람에 대한 공감과 친절함 표현
+* 다양한 의견, 관점 및 경험 존중
+* 건설적인 피드백 제공 및 정중하게 수락
+* 실수에 대한 책임을 지고 영향을 받은 사람들에게 사과하며 경험으로부터 배우기
+* 개인으로서 우리뿐만 아니라 전체 커뮤니티에 가장 좋은 것에 집중하기
 
-Examples of unacceptable behavior include:
+용납할 수 없는 행동의 예는 다음과 같습니다.
 
-* The use of sexualized language or imagery, and sexual attention or
-  advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
-  address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+* 성적인 언어 또는 이미지 사용, 모든 종류의 성적 관심 또는 접근
+* 트롤링, 모욕적이거나 경멸적인 댓글, 개인적 또는 정치적 공격
+* 공개적 또는 사적인 괴롭힘
+* 명시적인 허가 없이 타인의 실제 주소나 이메일 주소와 같은 개인 정보 게시
+* 직업적인 환경에서 합리적으로 부적절하다고 간주될 수 있는 기타 행위
 
-## Enforcement Responsibilities
+## 시행 책임
 
-Community leaders are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive,
-or harmful.
+커뮤니티 리더는 수용 가능한 행동 기준을 명확히 하고 시행할 책임이 있으며 부적절하거나 위협적이거나 공격적이거나 해롭다고 판단되는 모든 행동에 대해 적절하고 공정한 시정 조치를 취할 것입니다.
 
-Community leaders have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are
-not aligned to this Code of Conduct, and will communicate reasons for moderation
-decisions when appropriate.
+커뮤니티 리더는 이 행동 강령에 부합하지 않는 댓글, 커밋, 코드, 위키 편집, 문제 및 기타 기여를 제거, 편집 또는 거부할 권리와 책임이 있으며 적절한 경우 중재 결정 이유를 전달할 것입니다.
 
-## Scope
+## 범위
 
-This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
-posting via an official social media account, or acting as an appointed
-representative at an online or offline event.
+이 행동 강령은 모든 커뮤니티 공간 내에 적용되며 개인이 공공장소에서 공식적으로 커뮤니티를 대표하는 경우에도 적용됩니다. 커뮤니티를 대표하는 예로는 공식 이메일 주소 사용, 공식 소셜 미디어 계정을 통한 게시 또는 온라인 또는 오프라인 행사에서 임명된 대표로 활동하는 경우가 있습니다.
 
-## Enforcement
+## 시행
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-m.bui(at)anu.edu.au.
-All complaints will be reviewed and investigated promptly and fairly.
+학대적이거나 괴롭히거나 기타 용납할 수 없는 행동의 사례는 m.bui(at)anu.edu.au로 시행 책임이 있는 커뮤니티 리더에게 보고할 수 있습니다. 모든 불만 사항은 신속하고 공정하게 검토되고 조사될 것입니다.
 
-All community leaders are obligated to respect the privacy and security of the
-reporter of any incident.
+모든 커뮤니티 리더는 모든 사건 보고자의 개인 정보 보호 및 보안을 존중할 의무가 있습니다.
 
-## Enforcement Guidelines
+## 시행 지침
 
-Community leaders will follow these Community Impact Guidelines in determining
-the consequences for any action they deem in violation of this Code of Conduct:
+커뮤니티 리더는 이 행동 강령을 위반한다고 판단되는 모든 조치에 대한 결과를 결정할 때 다음 커뮤니티 영향 지침을 따릅니다.
 
-### 1. Correction
+### 1. 시정
 
-**Community Impact**: Use of inappropriate language or other behavior deemed
-unprofessional or unwelcome in the community.
+**커뮤니티 영향**: 커뮤니티에서 부적절하거나 전문가답지 못하거나 환영받지 못한다고 간주되는 부적절한 언어 또는 기타 행동 사용.
 
-**Consequence**: A private, written warning from community leaders, providing
-clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
+**결과**: 위반의 성격과 행동이 부적절했던 이유에 대한 설명을 제공하는 커뮤니티 리더의 비공개 서면 경고. 공개 사과가 요청될 수 있습니다.
 
-### 2. Warning
+### 2. 경고
 
-**Community Impact**: A violation through a single incident or series
-of actions.
+**커뮤니티 영향**: 단일 사건 또는 일련의 행동을 통한 위반.
 
-**Consequence**: A warning with consequences for continued behavior. No
-interaction with the people involved, including unsolicited interaction with
-those enforcing the Code of Conduct, for a specified period of time. This
-includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or
-permanent ban.
+**결과**: 지속적인 행동에 대한 결과가 있는 경고. 지정된 기간 동안 행동 강령을 시행하는 사람들과의 원치 않는 상호 작용을 포함하여 관련된 사람들과의 상호 작용 금지. 여기에는 커뮤니티 공간뿐만 아니라 소셜 미디어와 같은 외부 채널에서의 상호 작용 회피가 포함됩니다. 이러한 조건을 위반하면 일시적 또는 영구적인 금지로 이어질 수 있습니다.
 
-### 3. Temporary Ban
+### 3. 일시적 금지
 
-**Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
+**커뮤니티 영향**: 지속적인 부적절한 행동을 포함한 커뮤니티 기준의 심각한 위반.
 
-**Consequence**: A temporary ban from any sort of interaction or public
-communication with the community for a specified period of time. No public or
-private interaction with the people involved, including unsolicited interaction
-with those enforcing the Code of Conduct, is allowed during this period.
-Violating these terms may lead to a permanent ban.
+**결과**: 지정된 기간 동안 커뮤니티와의 모든 종류의 상호 작용 또는 공개적인 의사소통 금지. 이 기간 동안 행동 강령을 시행하는 사람들과의 원치 않는 상호 작용을 포함하여 관련된 사람들과의 공개적 또는 사적인 상호 작용은 허용되지 않습니다. 이러한 조건을 위반하면 영구적인 금지로 이어질 수 있습니다.
 
-### 4. Permanent Ban
+### 4. 영구적 금지
 
-**Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
-individual, or aggression toward or disparagement of classes of individuals.
+**커뮤니티 영향**: 지속적인 부적절한 행동, 개인에 대한 괴롭힘 또는 개인 집단에 대한 공격 또는 폄하를 포함한 커뮤니티 기준 위반 패턴 시연.
 
-**Consequence**: A permanent ban from any sort of public interaction within
-the community.
+**결과**: 커뮤니티 내에서의 모든 종류의 공개적인 상호 작용 영구 금지.
 
-## Attribution
+## 출처
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+이 행동 강령은 https://www.contributor-covenant.org/version/2/0/code_of_conduct.html에서 제공되는 [기여자 약속][homepage] 버전 2.0을 각색한 것입니다.
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
+커뮤니티 영향 지침은 [Mozilla의 행동 강령 시행 단계](https://github.com/mozilla/diversity)에서 영감을 받았습니다.
 
 [homepage]: https://www.contributor-covenant.org
 
-For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+이 행동 강령에 대한 일반적인 질문에 대한 답변은 https://www.contributor-covenant.org/faq의 FAQ를 참조하십시오. 번역은 https://www.contributor-covenant.org/translations에서 제공됩니다.

--- a/README.md
+++ b/README.md
@@ -8,164 +8,151 @@ IQ-TREE
 [![Build Status](https://github.com/iqtree/iqtree2/workflows/Build/badge.svg)](https://github.com/iqtree/iqtree2/actions)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
 
-Efficient and versatile phylogenomic software by maximum likelihood <http://www.iqtree.org>
+최대 가능도에 의한 효율적이고 다양한 기능을 제공하는 계통유전체학 소프트웨어 <http://www.iqtree.org>
 
-Introduction
+소개
 ------------
 
-The IQ-TREE software was created as the successor of IQPNNI and [TREE-PUZZLE](http://www.tree-puzzle.de) (thus the name IQ-TREE). IQ-TREE was motivated by the rapid accumulation of phylogenomic data, leading to a need for efficient phylogenomic software that can handle a large amount of data and provide more complex models of sequence evolution. To this end, IQ-TREE can utilize multicore computers and distributed parallel computing to speed up the analysis. IQ-TREE automatically performs checkpointing to resume an interrupted analysis.
+IQ-TREE 소프트웨어는 IQPNNI와 [TREE-PUZZLE](http://www.tree-puzzle.de)의 후속으로 만들어졌습니다(따라서 IQ-TREE라는 이름이 붙었습니다). IQ-TREE는 계통유전체학 데이터의 급격한 축적으로 인해 대량의 데이터를 처리하고 더 복잡한 염기 서열 진화 모델을 제공할 수 있는 효율적인 계통유전체학 소프트웨어의 필요성이 대두되면서 개발되었습니다. 이를 위해 IQ-TREE는 멀티코어 컴퓨터와 분산 병렬 컴퓨팅을 활용하여 분석 속도를 높일 수 있습니다. IQ-TREE는 중단된 분석을 재개하기 위해 자동으로 검사점(checkpointing)을 수행합니다.
 
-As input IQ-TREE accepts all common sequence alignment formats including PHYLIP, FASTA, Nexus, Clustal and MSF. As output IQ-TREE will write a self-readable report file (name suffix `.iqtree`), a NEWICK tree file (`.treefile`)  which can be visualized by tree viewer programs such as [FigTree](http://tree.bio.ed.ac.uk/software/figtree/), [Dendroscope](http://dendroscope.org) or [iTOL](http://itol.embl.de).
+입력으로 IQ-TREE는 PHYLIP, FASTA, Nexus, Clustal, MSF를 포함한 모든 일반적인 염기 서열 정렬 형식을 허용합니다. 출력으로 IQ-TREE는 자체적으로 읽을 수 있는 보고서 파일(이름 접미사 `.iqtree`), [FigTree](http://tree.bio.ed.ac.uk/software/figtree/), [Dendroscope](http://dendroscope.org) 또는 [iTOL](http://itol.embl.de)과 같은 트리 뷰어 프로그램으로 시각화할 수 있는 NEWICK 트리 파일(`.treefile`)을 작성합니다.
 
 
-Key features of IQ-TREE
+IQ-TREE의 주요 기능
 -----------------------
 
-* __Efficient search algorithm__: Fast and effective stochastic algorithm to reconstruct phylogenetic trees by maximum likelihood. IQ-TREE compares favorably to RAxML and PhyML in terms of likelihood while requiring similar amount of computing time ([Nguyen et al., 2015]).
-* __Ultrafast bootstrap__: An ultrafast bootstrap approximation (UFBoot) to assess branch supports. UFBoot is 10 to 40 times faster than RAxML rapid bootstrap and obtains less biased support values ([Minh et al., 2013]).
-* __Accurate model selection__: An ultrafast and automatic model selection (ModelFinder) which is 10 to 100 times faster than jModelTest and ProtTest. ModelFinder also finds best-fit partitioning scheme like PartitionFinder ([Kalyaanamoorthy et al., 2017]).
-* __Alignment simulation__: A flexible simulator (AliSim) which
-    allows to simulate sequence alignments under more realistic models than
-    Seq-Gen and INDELible ([Ly-Trong et al., 2023]).
-* __Phylogenetic testing__: Several fast branch tests like SH-aLRT and aBayes test ([Anisimova et al., 2011]) and tree topology tests like the approximately unbiased (AU) test ([Shimodaira, 2002]).
+* __효율적인 검색 알고리즘__: 최대 가능도에 의해 계통수를 재구성하는 빠르고 효과적인 확률적 알고리즘입니다. IQ-TREE는 비슷한 계산 시간을 요구하면서도 가능도 측면에서 RAxML 및 PhyML과 비교하여 유리합니다([Nguyen et al., 2015]).
+* __초고속 부트스트랩__: 분기 지원을 평가하기 위한 초고속 부트스트랩 근사(UFBoot)입니다. UFBoot는 RAxML 신속 부트스트랩보다 10~40배 빠르며 편향이 적은 지원 값을 얻습니다([Minh et al., 2013]).
+* __정확한 모델 선택__: jModelTest 및 ProtTest보다 10~100배 빠른 초고속 자동 모델 선택(ModelFinder)입니다. ModelFinder는 또한 PartitionFinder와 같이 가장 적합한 분할 체계를 찾습니다([Kalyaanamoorthy et al., 2017]).
+* __정렬 시뮬레이션__: Seq-Gen 및 INDELible보다 더 현실적인 모델 하에서 염기 서열 정렬을 시뮬레이션할 수 있는 유연한 시뮬레이터(AliSim)입니다([Ly-Trong et al., 2023]).
+* __계통 발생학적 테스트__: SH-aLRT 및 aBayes 테스트([Anisimova et al., 2011])와 같은 여러 빠른 분기 테스트와 근사적으로 편향되지 않은(AU) 테스트([Shimodaira, 2002])와 같은 트리 토폴로지 테스트가 있습니다.
 
 
-The strength of IQ-TREE is the availability of a wide variety of phylogenetic models:
+IQ-TREE의 강점은 다양한 계통 발생 모델을 사용할 수 있다는 것입니다.
 
-* __Common models__: All [common substitution models](http://www.iqtree.org/doc/Substitution-Models) for DNA, protein, codon, binary and morphological data with [rate heterogeneity among sites](http://www.iqtree.org/doc/Substitution-Models#rate-heterogeneity-across-sites) and [ascertainment bias correction](http://www.iqtree.org/doc/Substitution-Models#ascertainment-bias-correction) for e.g. SNP data.
-* __[Partition models](http://www.iqtree.org/doc/Complex-Models/#partition-models)__: Allowing individual models for different genomic loci (e.g. genes or codon positions), mixed data types, mixed rate heterogeneity types, linked or unlinked branch lengths between partitions.
-* __Mixture Models__: [fully customizable mixture models](http://www.iqtree.org/doc/Complex-Models#mixture-models) and [empirical protein mixture models](http://www.iqtree.org/doc/Substitution-Models#protein-models) and.
-* __Polymorphism-aware models (PoMo)__: <http://www.iqtree.org/doc/Polymorphism-Aware-Models>
+* __일반 모델__: DNA, 단백질, 코돈, 이진 및 형태학적 데이터에 대한 모든 [일반적인 치환 모델](http://www.iqtree.org/doc/Substitution-Models)과 [사이트 간 비율 이질성](http://www.iqtree.org/doc/Substitution-Models#rate-heterogeneity-across-sites) 및 예를 들어 SNP 데이터에 대한 [확인 편향 보정](http://www.iqtree.org/doc/Substitution-Models#ascertainment-bias-correction)을 제공합니다.
+* __[분할 모델](http://www.iqtree.org/doc/Complex-Models/#partition-models)__: 서로 다른 게놈 위치(예: 유전자 또는 코돈 위치), 혼합 데이터 유형, 혼합 비율 이질성 유형, 분할 간 연결되거나 연결되지 않은 분기 길이에 대해 개별 모델을 허용합니다.
+* __혼합 모델__: [완전 맞춤형 혼합 모델](http://www.iqtree.org/doc/Complex-Models#mixture-models) 및 [경험적 단백질 혼합 모델](http://www.iqtree.org/doc/Substitution-Models#protein-models)을 제공합니다.
+* __다형성 인식 모델 (PoMo)__: <http://www.iqtree.org/doc/Polymorphism-Aware-Models>
 
 
-IQ-TREE web service
+IQ-TREE 웹 서비스
 -------------------
 
-For a quick start you can also try the IQ-TREE web server, which performs 
-online computation using a dedicated computing cluster. It is very easy to use 
-with as few as just 3 clicks! Try it out at:
+빠른 시작을 위해 전용 컴퓨팅 클러스터를 사용하여 온라인 계산을 수행하는 IQ-TREE 웹 서버를 사용해 볼 수도 있습니다. 단 3번의 클릭만으로 매우 쉽게 사용할 수 있습니다! 다음에서 사용해 보세요.
 
-* Vienna Bioinformatics Cluster: <http://iqtree.cibiv.univie.ac.at>
-* CIPRES Gateway: <https://www.phylo.org>
-* Los Alamos Laboratories: <https://www.hiv.lanl.gov/content/sequence/IQTREE/iqtree.html>
+* 비엔나 생물정보학 클러스터: <http://iqtree.cibiv.univie.ac.at>
+* CIPRES 게이트웨이: <https://www.phylo.org>
+* 로스앨러모스 국립 연구소: <https://www.hiv.lanl.gov/content/sequence/IQTREE/iqtree.html>
 
-User support
+사용자 지원
 ------------
 
-Please refer to the [user documentation](http://www.iqtree.org/doc/) and 
-[frequently asked questions](http://www.iqtree.org/doc/Frequently-Asked-Questions). 
-If you have further questions and feedback, please create a topic at 
-[Github discussions](https://github.com/iqtree/iqtree2/discussions).
-For feature requests bug reports please post a topic at
-[Github issues](https://github.com/iqtree/iqtree2/issues).
+[사용자 설명서](http://www.iqtree.org/doc/) 및 [자주 묻는 질문](http://www.iqtree.org/doc/Frequently-Asked-Questions)을 참조하십시오. 추가 질문이나 피드백이 있는 경우 [Github 토론](https://github.com/iqtree/iqtree2/discussions)에 주제를 만드십시오. 기능 요청이나 버그 보고는 [Github 문제](https://github.com/iqtree/iqtree2/issues)에 주제를 게시하십시오.
 
-Citations
+인용
 ---------
 
-General citation for IQ-TREE 2:
+IQ-TREE 2에 대한 일반적인 인용:
 
 * B.Q. Minh, H.A. Schmidt, O. Chernomor, D. Schrempf, M.D. Woodhams, A. von Haeseler, R. Lanfear (2020) 
-  IQ-TREE 2: New models and efficient methods for phylogenetic inference in the genomic era.
+  IQ-TREE 2: 게놈 시대의 계통 발생 추론을 위한 새로운 모델 및 효율적인 방법.
   *Mol. Biol. Evol.*, 37:1530-1534. <https://doi.org/10.1093/molbev/msaa015>
 
-Moreover, there are other papers associated with notable features in IQ-TREE,
-which are normally mentioned in the corresponding documentation. We ask that you also
-cite these papers, which are important for us to obtain fundings to 
-continuously maintain the code of IQ-TREE. These papers are also listed below.
+또한 IQ-TREE의 주목할 만한 기능과 관련된 다른 논문들이 있으며, 일반적으로 해당 설명서에 언급되어 있습니다. IQ-TREE 코드를 지속적으로 유지하기 위한 자금 확보에 중요한 이러한 논문들도 인용해 주시기를 부탁드립니다. 이러한 논문들은 아래에도 나열되어 있습니다.
 
-When using tree mixture models (MAST) please cite:
+트리 혼합 모델(MAST)을 사용하는 경우 다음을 인용하십시오.
 
 * T.K.F. Wong, C. Cherryh, A.G. Rodrigo, M.W. Hahn, B.Q. Minh, R. Lanfear (2024)
-  MAST: Phylogenetic Inference with Mixtures Across Sites and Trees.
-  _Syst. Biol._, in press. <https://doi.org/10.1093/sysbio/syae008>
+  MAST: 사이트와 트리에 걸친 혼합을 이용한 계통 발생 추론.
+  _Syst. Biol._, 인쇄 중. <https://doi.org/10.1093/sysbio/syae008>
 
-When computing concordance factors please cite:
+일치 계수(concordance factors)를 계산하는 경우 다음을 인용하십시오.
 
 * Y.K. Mo, R. Lanfear, M.W. Hahn, B.Q. Minh (2023)
-  Updated site concordance factors minimize effects of homoplasy and taxon sampling.
+  업데이트된 사이트 일치 계수는 동형 형질 및 분류군 샘플링의 영향을 최소화합니다.
   _Bioinformatics_, 39:btac741. <https://doi.org/10.1093/bioinformatics/btac741>
 
-When using AliSim to simulate alignments please cite:
+AliSim을 사용하여 정렬을 시뮬레이션하는 경우 다음을 인용하십시오.
 
 * N. Ly-Trong, G.M.J. Barca, B.Q. Minh (2023)
-  AliSim-HPC: parallel sequence simulator for phylogenetics.
+  AliSim-HPC: 계통 발생학을 위한 병렬 염기 서열 시뮬레이터.
   *Bioinformatics*, 39:btad540. <https://doi.org/10.1093/bioinformatics/btad540>
 
-When estimating amino-acid Q matrix please cite:
+아미노산 Q 행렬을 추정하는 경우 다음을 인용하십시오.
 
 * B.Q. Minh, C. Cao Dang, L.S. Vinh, R. Lanfear (2021)
-  QMaker: Fast and accurate method to estimate empirical models of protein evolution.
+  QMaker: 단백질 진화의 경험적 모델을 추정하는 빠르고 정확한 방법.
   _Syst. Biol._, 70:1046–1060. <https://doi.org/10.1093/sysbio/syab010>
 
-When using the heterotachy GHOST model "+H" please cite:
+이종분포 GHOST 모델 "+H"를 사용하는 경우 다음을 인용하십시오.
 
 * S.M. Crotty, B.Q. Minh, N.G. Bean, B.R. Holland, J. Tuke, L.S. Jermiin, A. von Haeseler (2020)
-  GHOST: Recovering Historical Signal from Heterotachously Evolved Sequence Alignments.
+  GHOST: 이종분포적으로 진화한 염기 서열 정렬에서 역사적 신호 복구.
   _Syst. Biol._, 69:249-264. <https://doi.org/10.1093/sysbio/syz051>
 
-When using the tests of symmetry please cite:
+대칭성 테스트를 사용하는 경우 다음을 인용하십시오.
 
 * S. Naser-Khdour, B.Q. Minh, W. Zhang, E.A. Stone, R. Lanfear (2019) 
-  The Prevalence and Impact of Model Violations in Phylogenetic Analysis. 
+  계통 발생 분석에서 모델 위반의 유병률 및 영향.
   *Genome Biol. Evol.*, 11:3341-3352. <https://doi.org/10.1093/gbe/evz193>
 
-When using polymorphism-aware models please cite:
+다형성 인식 모델을 사용하는 경우 다음을 인용하십시오.
 
 * D. Schrempf, B.Q. Minh, A. von Haeseler, C. Kosiol (2019) 
-  Polymorphism-aware species trees with advanced mutation models, bootstrap, and rate heterogeneity. 
+  고급 돌연변이 모델, 부트스트랩 및 비율 이질성을 갖춘 다형성 인식 종 트리.
   *Mol. Biol. Evol.*, 36:1294–1301. <https://doi.org/10.1093/molbev/msz043>
 
-For the ultrafast bootstrap (UFBoot) please cite:
+초고속 부트스트랩(UFBoot)의 경우 다음을 인용하십시오.
 
 * D.T. Hoang, O. Chernomor, A. von Haeseler, B.Q. Minh, and L.S. Vinh (2018) 
-  UFBoot2: Improving the ultrafast bootstrap approximation. 
+  UFBoot2: 초고속 부트스트랩 근사 개선.
   *Mol. Biol. Evol.*, 35:518–522. <https://doi.org/10.1093/molbev/msx281>
 
-When using posterior mean site frequency model (PMSF) please cite:
+사후 평균 사이트 빈도 모델(PMSF)을 사용하는 경우 다음을 인용하십시오.
 
 * H.C. Wang, B.Q. Minh, S. Susko, A.J. Roger (2018) 
-  Modeling site heterogeneity with posterior mean site frequency profiles 
-  accelerates accurate phylogenomic estimation. 
+  사후 평균 사이트 빈도 프로파일을 사용한 사이트 이질성 모델링은 정확한 계통유전체학적 추정을 가속화합니다.
   *Syst. Biol.*, 67:216–235. <https://doi.org/10.1093/sysbio/syx068>
 
-When using ModelFinder please cite:
+ModelFinder를 사용하는 경우 다음을 인용하십시오.
 
 * S. Kalyaanamoorthy, B.Q. Minh, T.K.F. Wong, A. von Haeseler, L.S. Jermiin (2017) 
-  ModelFinder: Fast model selection for accurate phylogenetic estimates. 
+  ModelFinder: 정확한 계통 발생 추정을 위한 빠른 모델 선택.
   *Nat. Methods*, 14:587-589. <https://doi.org/10.1038/nmeth.4285>
 
-When using partition models please cite:
+분할 모델을 사용하는 경우 다음을 인용하십시오.
 
 * O. Chernomor, A. von Haeseler, B.Q. Minh (2016) 
-  Terrace aware data structure for phylogenomic inference from supermatrices. 
+  슈퍼매트릭스로부터 계통유전체학적 추론을 위한 테라스 인식 데이터 구조.
   *Syst. Biol.*, 65:997-1008. <https://doi.org/10.1093/sysbio/syw037>
 
-When using IQ-TREE web server please cite:
+IQ-TREE 웹 서버를 사용하는 경우 다음을 인용하십시오.
 
 * J. Trifinopoulos, L.-T. Nguyen, A. von Haeseler, B.Q. Minh (2016) 
-  W-IQ-TREE: a fast online phylogenetic tool for maximum likelihood analysis.
+  W-IQ-TREE: 최대 가능도 분석을 위한 빠른 온라인 계통 발생 도구.
   *Nucleic Acids Res.*, 44:W232-W235. <https://doi.org/10.1093/nar/gkw256>
 
-When using IQ-TREE version 1 please cite:
+IQ-TREE 버전 1을 사용하는 경우 다음을 인용하십시오.
 
 * L. Nguyen, H.A. Schmidt, A. von Haeseler, B.Q. Minh (2015)
-  IQ-TREE: A Fast and Effective Stochastic Algorithm for Estimating Maximum-Likelihood Phylogenies.
+  IQ-TREE: 최대 가능도 계통수를 추정하기 위한 빠르고 효과적인 확률적 알고리즘.
   _Mol. Biol. and Evol._, 32:268-274. <https://doi.org/10.1093/molbev/msu300>
 
-#### Credits and Acknowledgements
+#### 크레딧 및 감사의 말
 
-Some parts of the code were taken from the following packages/libraries: [Phylogenetic likelihood library](http://www.libpll.org), [TREE-PUZZLE](http://www.tree-puzzle.de), 
+코드의 일부는 다음 패키지/라이브러리에서 가져왔습니다: [Phylogenetic likelihood library](http://www.libpll.org), [TREE-PUZZLE](http://www.tree-puzzle.de),
 [BIONJ](http://dx.doi.org/10.1093/oxfordjournals.molbev.a025808), [Nexus Class Libary](http://dx.doi.org/10.1093/bioinformatics/btg319), [Eigen library](http://eigen.tuxfamily.org/),
 [SPRNG library](http://www.sprng.org), [Zlib library](http://www.zlib.net), [gzstream library](http://www.cs.unc.edu/Research/compgeom/gzstream/), [vectorclass library](http://www.agner.org/optimize/), [GNU scientific library](https://www.gnu.org/software/gsl/).
 
 
-IQ-TREE was funded by the [Austrian Science Fund - FWF](http://www.fwf.ac.at/) 
-(grant no. I 760-B17 from 2012-2015 and and I 2508-B29 from 2016-2019),
-the [University of Vienna](https://www.univie.ac.at/) (Initiativkolleg I059-N),
-the [Australian National University](https://www.anu.edu.au),
-[Chan-Zuckerberg Initiative](https://chanzuckerberg.com) (open source software for science grants),
-[Simons Foundation](https://www.simonsfoundation.org), [Moore Foundation](https://www.moore.org),
-and [Australian Research Council](https://www.arc.gov.au).
+IQ-TREE는 [오스트리아 과학 기금 - FWF](http://www.fwf.ac.at/)
+(2012-2015년 보조금 번호 I 760-B17 및 2016-2019년 보조금 번호 I 2508-B29),
+[비엔나 대학교](https://www.univie.ac.at/) (Initiativkolleg I059-N),
+[호주 국립 대학교](https://www.anu.edu.au),
+[챈 저커버그 이니셔티브](https://chanzuckerberg.com) (과학 보조금을 위한 오픈 소스 소프트웨어),
+[사이먼스 재단](https://www.simonsfoundation.org), [무어 재단](https://www.moore.org),
+및 [호주 연구 위원회](https://www.arc.gov.au)의 지원을 받았습니다.
 
 
 [Anisimova et al., 2011]: http://dx.doi.org/10.1093/sysbio/syr041
@@ -175,4 +162,3 @@ and [Australian Research Council](https://www.arc.gov.au).
 [Minh et al., 2013]: http://dx.doi.org/10.1093/molbev/mst024
 [Nguyen et al., 2015]: http://dx.doi.org/10.1093/molbev/msu300
 [Shimodaira, 2002]: http://dx.doi.org/10.1080/10635150290069913
-

--- a/terrace/README.md
+++ b/terrace/README.md
@@ -1,112 +1,112 @@
-Identifying equally scoring trees in phylogenomics with incomplete data using Gentrius
+Gentrius를 사용하여 불완전한 데이터가 있는 계통유전체학에서 동일한 점수를 가진 트리 식별하기
 =======
 
-Gentrius is a deterministic algorithm to generate trees from unrooted incomplete subtrees. It phylogenetics it can be applied to trees inferred with common methods such as supermatrix and supertrees to generate a set of all trees that have the same induced subtrees as an inferred tree. This set is called a stand. Stands are extremely valuable, since under many scoring functions all trees from the same stand have identical analytical score. Read more in our manuscript.
+Gentrius는 뿌리가 없는 불완전한 하위 트리로부터 트리를 생성하는 결정론적 알고리즘입니다. 계통유전체학에서는 슈퍼매트릭스 및 슈퍼트리와 같은 일반적인 방법으로 추론된 트리에 적용하여 추론된 트리와 동일한 유도된 하위 트리를 갖는 모든 트리의 집합을 생성할 수 있습니다. 이 집합을 스탠드(stand)라고 합니다. 스탠드는 많은 점수 산정 함수 하에서 동일한 스탠드의 모든 트리가 동일한 분석 점수를 갖기 때문에 매우 가치가 있습니다. 자세한 내용은 저희 원고를 참조하십시오.
 
-Preprint is available from bioRxiv
-* O. Chernomor, C. Elgert, A. von Haeseler (2023) Identifying equally scoring trees in phylogenomics with incomplete data using Gentrius
+사전 인쇄본은 bioRxiv에서 제공됩니다.
+* O. Chernomor, C. Elgert, A. von Haeseler (2023) Gentrius를 사용하여 불완전한 데이터가 있는 계통유전체학에서 동일한 점수를 가진 트리 식별하기
 
-Analysis with Gentrius
+Gentrius를 이용한 분석
 -----------------------
-### Basic Input
+### 기본 입력
 -----
-There are several ways and inputs one can use to start the analysis. Here are the examples of command lines:
+분석을 시작하는 데 사용할 수 있는 여러 가지 방법과 입력이 있습니다. 다음은 명령줄 예시입니다.
 
-1.  __iqtree2 -gentrius <file 1> -pr_ab_matrix <file 2>__
-2.  __iqtree2 -gentrius <file 1> -s <file 3> -p <file 4>__
-3.  __iqtree2 -gentrius <file 5>__
+1.  __iqtree2 -gentrius <파일 1> -pr_ab_matrix <파일 2>__
+2.  __iqtree2 -gentrius <파일 1> -s <파일 3> -p <파일 4>__
+3.  __iqtree2 -gentrius <파일 5>__
 
-    - File 1: a phylogenetic tree to be analysed
+    - 파일 1: 분석할 계통수
 
-    - File 2: a species per locus presence-absence matrix. First line is a number of species and the number of loci. Other lines contain species name followed by 0's and 1's (with space separator) to indicate presence/absence of gene sequences for corresponding loci. 
+    - 파일 2: 유전자좌당 종 존재-부재 매트릭스. 첫 번째 줄은 종의 수와 유전자좌의 수입니다. 다른 줄에는 해당 유전자좌에 대한 유전자 서열의 존재/부재를 나타내는 종 이름과 0 또는 1(공백 구분자)이 포함됩니다.
 
-            Example: 
+            예시:
             ---------------
-            5 3  
-            species_1 0 1 1  
-            species_2 1 0 1  
-            species_3 1 1 1  
-            species_4 1 1 0  
-            species_5 1 1 1  
+            5 3
+            species_1 0 1 1
+            species_2 1 0 1
+            species_3 1 1 1
+            species_4 1 1 0
+            species_5 1 1 1
 
-    - File 3: an alignment file with concatenated loci
-    - File 4: a partition info file for the alignment in file 3
-    - File 5: contains a set of subtrees to be analysed
+    - 파일 3: 연결된 유전자좌가 있는 정렬 파일
+    - 파일 4: 파일 3의 정렬에 대한 분할 정보 파일
+    - 파일 5: 분석할 하위 트리 집합을 포함합니다.
 
-### Stopping Rules
+### 중지 규칙
 -----
-As the underlying problems are computationally hard, we use three different rules to stop the analysis. The thresholds can be changed by the corresponding options.
+기본 문제는 계산적으로 어렵기 때문에 분석을 중지하기 위해 세 가지 다른 규칙을 사용합니다. 해당 옵션을 사용하여 임계값을 변경할 수 있습니다.
 
-- __Rule 1:__ stop the analysis after generating NUM of trees. Default value: 1MLN trees.   
-         __-g_stop_t NUM__  - To change the threshold  
-         __-g_stop_t 0__  - To turn off the rule  
+- __규칙 1:__ NUM 개의 트리를 생성한 후 분석을 중지합니다. 기본값: 1백만 개 트리.
+         __-g_stop_t NUM__  - 임계값 변경
+         __-g_stop_t 0__  - 규칙 끄기
 
-- __Rule 2:__ stop the analysis after NUM of intermediate trees were visited. Default value: 10MLN trees.       
-         __-g_stop_i NUM__  - To change the threshold  
-         __-g_stop_i 0__  - To turn off the rule  
+- __규칙 2:__ NUM 개의 중간 트리를 방문한 후 분석을 중지합니다. 기본값: 1천만 개 트리.
+         __-g_stop_i NUM__  - 임계값 변경
+         __-g_stop_i 0__  - 규칙 끄기
 
-- __Rule 3:__ stop the analysis after NUM hours (CPU time). Default: 168 hours (7 days).   
-         __-g_stop_h NUM__  - To change the threshold  
-         __-g_stop_h 0__  - To turn off the rule  
+- __규칙 3:__ NUM 시간(CPU 시간) 후에 분석을 중지합니다. 기본값: 168시간(7일).
+         __-g_stop_h NUM__  - 임계값 변경
+         __-g_stop_h 0__  - 규칙 끄기
 
-- To turn off all stopping rules use:  
-         __-g_non_stop__ 
+- 모든 중지 규칙을 끄려면 다음을 사용하십시오.
+         __-g_non_stop__
 
 
-### Output
+### 출력
 -----
-If no other option is used, the ouput is just the log file. The following information is provided about the analysis:
+다른 옵션을 사용하지 않으면 출력은 로그 파일뿐입니다. 분석에 대한 다음 정보가 제공됩니다.
 
-    INFORMATION about input dataset:  
-    Number of taxa: NUM  
-    Number of partitions: NUM  
-    Number of special taxa (row sum = 1): NUM  
-    % of missing entries in pr_ab_matrix: NUM  
-    Number of taxa on initial tree: NUM  
-    Number of taxa to be inserted: NUM  
+    입력 데이터 세트에 대한 정보:
+    분류군 수: NUM
+    분할 수: NUM
+    특수 분류군 수 (행 합계 = 1): NUM
+    pr_ab_matrix에서 누락된 항목 비율: NUM
+    초기 트리의 분류군 수: NUM
+    삽입할 분류군 수: NUM
 
-    SUMMARY:  
-    Number of trees on stand: NUM  
-    Number of intermediated trees visited: NUM  
-    Number of dead ends encountered: NUM  
-
-
-Here are additional options to output more information:
-
-__-g_print__    - Write all generated trees into a file.  
->WARNING: There might be millions of trees! Use the next option to set the limit on the number of trees to be written into a file.  
-
-__-g_print_lim NUM__  - Limit on the number of trees to be written to a file  
->NOTE: The program will continue generation, but will stop writing trees.  
->WARNING: Do not use summary statistics just on a fraction of trees! Due to the way the generation is performed, consecutive trees have more similar topologies. Therefore, the summary statistics for a fraction of generated trees might be misleading.
-
-__-g_print_induced__  - Write induced partition subtrees  
-__-g_print_m__ - Write corresponding presence-absence matrix  
+    요약:
+    스탠드의 트리 수: NUM
+    방문한 중간 트리 수: NUM
+    발생한 막다른 골목 수: NUM
 
 
-### Additional Analyses
+더 많은 정보를 출력하기 위한 추가 옵션은 다음과 같습니다.
+
+__-g_print__    - 생성된 모든 트리를 파일에 씁니다.
+>경고: 수백만 개의 트리가 있을 수 있습니다! 파일에 쓸 트리 수를 제한하려면 다음 옵션을 사용하십시오.
+
+__-g_print_lim NUM__  - 파일에 쓸 트리 수 제한
+>참고: 프로그램은 계속 생성하지만 트리 쓰기를 중지합니다.
+>경고: 트리의 일부에 대해서만 요약 통계를 사용하지 마십시오! 생성 방식 때문에 연속적인 트리는 더 유사한 토폴로지를 갖습니다. 따라서 생성된 트리의 일부에 대한 요약 통계는 오해의 소지가 있을 수 있습니다.
+
+__-g_print_induced__  - 유도된 분할 하위 트리 쓰기
+__-g_print_m__ - 해당 존재-부재 매트릭스 쓰기
+
+
+### 추가 분석
 -----
 
-* __Alternative approach: alternative initial trees__   
-Due to complexity there might be cases, when Gentrius fails to generate any tree in reasonable time. In this case one can try generating trees using alternative approach: remove NUM of leaves, generate trees by re-inserting these removed leaves. This technique cannot guarantee generating all trees from the stand (i.e. trees compatible with a set of subtrees). However, by using this approach on simulated datasets it was possible to generate millions of trees for complex examples providing a lower bound on stand size.
+* __대안적 접근 방식: 대안적 초기 트리__
+복잡성으로 인해 Gentrius가 합리적인 시간 내에 트리를 생성하지 못하는 경우가 있을 수 있습니다. 이 경우 대안적인 접근 방식을 사용하여 트리를 생성해 볼 수 있습니다. NUM 개의 리프를 제거하고 이러한 제거된 리프를 다시 삽입하여 트리를 생성합니다. 이 기술은 스탠드의 모든 트리(즉, 하위 트리 집합과 호환되는 트리)를 생성하는 것을 보장할 수는 없습니다. 그러나 시뮬레이션된 데이터 세트에서 이 접근 방식을 사용하면 복잡한 예에 대해 수백만 개의 트리를 생성하여 스탠드 크기의 하한을 제공할 수 있었습니다.
 
-    __-g_rm_leaves NUM__   - To use alternative approach
+    __-g_rm_leaves NUM__   - 대안적 접근 방식 사용
 
-* __Test set of trees__   
-It is also possible to check, if some trees from a query set have identical set of subtrees as a representative tree (if they belong to the same stand). 
+* __트리 집합 테스트__
+쿼리 집합의 일부 트리가 대표 트리와 동일한 하위 트리 집합을 갖는지(동일한 스탠드에 속하는지) 확인할 수도 있습니다.
 
-    __-g_query FILE__  - To perform check for a set of trees
+    __-g_query FILE__  - 트리 집합에 대한 확인 수행
 
 
-User support
+사용자 지원
 ------------
-If you have further questions, feedback, feature requests, and bug reports, please sign up the following Google group (if not done yet) and post a topic to the 
+추가 질문, 피드백, 기능 요청 및 버그 보고가 있는 경우 다음 Google 그룹에 가입(아직 가입하지 않은 경우)하고 다음 주소로 주제를 게시하십시오.
 
 <https://groups.google.com/d/forum/iqtree>
 
-_The average response time is one working day._
+_평균 응답 시간은 근무일 기준 1일입니다._
 
-Citations
+인용
 ---------
-Preprint is available from bioRxiv
-* O. Chernomor, C. Elgert, A. von Haeseler (2023) Identifying equally scoring trees in phylogenomics with incomplete data using Gentrius
+사전 인쇄본은 bioRxiv에서 제공됩니다.
+* O. Chernomor, C. Elgert, A. von Haeseler (2023) Gentrius를 사용하여 불완전한 데이터가 있는 계통유전체학에서 동일한 점수를 가진 트리 식별하기

--- a/terraphast/documentation/Changelog.md
+++ b/terraphast/documentation/Changelog.md
@@ -1,27 +1,27 @@
-Since 1st meeting
+첫 회의 이후 변경 사항
 =================
 
-Optimizations
+최적화
 -------------
 
-* implement bitvector with rank support
-* use bitvector instead of index vectors for subsets
-* inline lots of often-used methods
-* deduplicate constraints
-* remap constraints (removing inner nodes from the numbering)
-* halved union-find storage by out-of-bounds parent trick
-* avoid allocations by reusing old storage
-* some micro-optimizations
+* 순위 지원 비트벡터 구현
+* 부분 집합에 인덱스 벡터 대신 비트벡터 사용
+* 자주 사용되는 여러 메소드 인라인 처리
+* 제약 조건 중복 제거
+* 제약 조건 재매핑 (번호 매기기에서 내부 노드 제거)
+* 범위 벗어난 부모 트릭으로 합집합-찾기 저장 공간 절반으로 축소
+* 이전 저장 공간 재사용으로 할당 방지
+* 일부 마이크로 최적화
 
-Fixes and Features
+수정 및 기능
 ------------------
 
-* fast terrace check without traversing the tree to the end
-* fixed subtree computation (problematic input data caused an assertion to fail)
-* fix counting bug (communication problem)
-* don't count incorrectly rooted trees
-* extracted all computations to callback methods
-* implemented logging + stack state decorators
-* implemented isomorphy check
-* Visual C++ compatibility checked with appveyor
-* extracted intrinsics to stay portable
+* 트리 끝까지 순회하지 않고 빠른 테라스 확인
+* 하위 트리 계산 수정 (문제가 있는 입력 데이터로 인해 어설션 실패 발생)
+* 카운팅 버그 수정 (통신 문제)
+* 잘못된 루트를 가진 트리 카운트하지 않음
+* 모든 계산을 콜백 메소드로 추출
+* 로깅 + 스택 상태 데코레이터 구현
+* 동형 검사 구현
+* Appveyor로 Visual C++ 호환성 확인
+* 이식성을 유지하기 위해 내장 함수 추출

--- a/terraphast/documentation/Dependencies.md
+++ b/terraphast/documentation/Dependencies.md
@@ -1,21 +1,19 @@
-
-Dependencies
+의존성
 ============
 
-This library has multiple Dependencies
+이 라이브러리에는 여러 의존성이 있습니다.
 
 
-Detailed List
+세부 목록
 -------------
 
-* [Catch](https://github.com/philsquared/Catch). The header `catch.hpp` is supposed to be in the default include-path. The framework is avaiable multiple distros under the name `catch`.
+* [Catch](https://github.com/philsquared/Catch). 헤더 `catch.hpp`는 기본 포함 경로에 있어야 합니다. 이 프레임워크는 `catch`라는 이름으로 여러 배포판에서 사용할 수 있습니다.
 * ...
 
-Copyable List for installation
+설치를 위한 복사 가능한 목록
 ------------------------------
 
 
 ```
 catch
 ```
-

--- a/vectorclass/changelog.txt
+++ b/vectorclass/changelog.txt
@@ -1,176 +1,169 @@
-Change log for vectorclass.zip
+vectorclass.zip 변경 로그
 ------------------------------
 
-Projected future version, 2018:
-  * use mask registers for boolean vectors of all sizes with AVX512VL
-  * use C++14
-  * replace long template argument lists by constant arrays
-  
-2017-07-27 version 1.30
-  * fixed bug in permute8f for a particular combination of indexes  
-  
-2017-05-10 version 1.29
-  * Reversed Apple Clang patch in version 1.28 because the problem has reoccurred in
-    later versions of Clang
-  
-2017-05-02 version 1.28
-  * Fixed problem with Apple Clang version 6.2 in vectorf128.h
-  * Fixed return type for Vec8sb operator > (Vec8us, Vec8us)  
-  * cpuid function modified in instrset_detect.cpp
-  
-2017-02-19 version 1.27
-  * fixed problem with scatter functions in MS Visual Studio  
-  
-2016-12-21 version 1.26
-  * added constant4ui template
-  * fixed error for complexvec.h with clang  
-  * fixed error in vectormath_exp.h for MAX_VECTOR_SIZE < 512
+예상 향후 버전, 2018년:
+  * AVX512VL을 사용하여 모든 크기의 부울 벡터에 마스크 레지스터 사용
+  * C++14 사용
+  * 긴 템플릿 인수 목록을 상수 배열로 대체
 
-2016-11-25 version 1.25
-  * scatter functions
-  * new functions to_float for unsigned integer vectors
-  * instrset_detect function can detect AVX512VL, AVX512BW, AVX512DQ
-  * functions hasF16C and hasAVX512ER for detecting instruction set extensions
-  * fix bugs in horizontal_and and pow(0,0) for AVX512
-  * functions improved for AVX512 and AVX512VL: pow, approx_recipr,  
+2017-07-27 버전 1.30
+  * 특정 인덱스 조합에 대한 permute8f의 버그 수정
+
+2017-05-10 버전 1.29
+  * Clang 최신 버전에서 문제가 다시 발생하여 버전 1.28의 Apple Clang 패치 되돌림
+
+2017-05-02 버전 1.28
+  * vectorf128.h에서 Apple Clang 버전 6.2 문제 수정
+  * Vec8sb 연산자 > (Vec8us, Vec8us)의 반환 유형 수정
+  * instrset_detect.cpp에서 cpuid 함수 수정
+
+2017-02-19 버전 1.27
+  * MS Visual Studio에서 분산 함수의 문제 수정
+
+2016-12-21 버전 1.26
+  * constant4ui 템플릿 추가
+  * clang에서 complexvec.h 오류 수정
+  * MAX_VECTOR_SIZE < 512인 경우 vectormath_exp.h 오류 수정
+
+2016-11-25 버전 1.25
+  * 분산 함수
+  * 부호 없는 정수 벡터에 대한 새로운 to_float 함수
+  * instrset_detect 함수는 AVX512VL, AVX512BW, AVX512DQ를 감지할 수 있음
+  * 명령어 세트 확장을 감지하는 hasF16C 및 hasAVX512ER 함수
+  * AVX512에 대한 horizontal_and 및 pow(0,0) 버그 수정
+  * AVX512 및 AVX512VL에 대해 개선된 함수: pow, approx_recipr,
       approx_rsqrt
-  * functions improved for AVX512DQ: 64 bit multiplication, to_double,
-      32 and 64 bit rotate_left, round_to_int64, truncate_to_int64
-  * functions improved for AVX512ER: approx_recipr, approx_rsqrt,
-      exponential functions
+  * AVX512DQ에 대해 개선된 함수: 64비트 곱셈, to_double,
+      32비트 및 64비트 rotate_left, round_to_int64, truncate_to_int64
+  * AVX512ER에 대해 개선된 함수: approx_recipr, approx_rsqrt,
+      지수 함수
 
-2016-10-31 version 1.24
-  * fix bug in Vec8uq constructor in vectori512e.h
+2016-10-31 버전 1.24
+  * vectori512e.h의 Vec8uq 생성자 버그 수정
 
-2016-09-27 version 1.23
-  * temporary fix of a problem in Clang version 3.9 inserted in vectorf128.h
+2016-09-27 버전 1.23
+  * vectorf128.h에 Clang 버전 3.9 문제 임시 수정 삽입
 
-2016-05-03 version 1.22
-  * added optional namespace
-  * fixed problem with decimal.h  
+2016-05-03 버전 1.22
+  * 선택적 네임스페이스 추가
+  * decimal.h 문제 수정
 
-2016-04-24 version 1.21
-  * fix problems with XOP option in gcc
-  * improved horizontal_and/or for sse2
-  * improved Vec2q and Vec4q constructor on Microsoft Visual Studio 2015
-  * removed warnings by gcc option -Wcast-qual  
+2016-04-24 버전 1.21
+  * gcc에서 XOP 옵션 문제 수정
+  * sse2에 대한 horizontal_and/or 개선
+  * Microsoft Visual Studio 2015에서 Vec2q 및 Vec4q 생성자 개선
+  * gcc 옵션 -Wcast-qual에 의한 경고 제거
 
-2015-12-04 version 1.20
-  * round functions: suppress precision exception under SSE4.1 and higher
-  * fix compiler problems with AVX512 multiplication in gcc version 5.1
-  * fix compiler problems with pow function in Microsoft Visual Studio 2015
+2015-12-04 버전 1.20
+  * round 함수: SSE4.1 이상에서 정밀도 예외 억제
+  * gcc 버전 5.1에서 AVX512 곱셈 컴파일러 문제 수정
+  * Microsoft Visual Studio 2015에서 pow 함수 컴파일러 문제 수정
 
-2015-11-14 version 1.19
-  * fix various problems with Clang compiler
+2015-11-14 버전 1.19
+  * Clang 컴파일러 관련 다양한 문제 수정
 
-2015-09-25 version 1.18
-  * fix compiler error for Vec8s divide_by_i(Vec8s const & x) under Clang compiler
-  * fix error in Vec4d::size() in vectorf256e.h
+2015-09-25 버전 1.18
+  * Clang 컴파일러에서 Vec8s divide_by_i(Vec8s const & x) 컴파일러 오류 수정
+  * vectorf256e.h의 Vec4d::size() 오류 수정
 
-2015-07-31 version 1.17
-  * improved operator > for Vec4uq
-  * more special cases in blend4q
-  * nan_code functions made static inline
-  * template parameter BTYPE renamed to BVTYPE in mathematical functions to avoid clash
-      with macro named BTYPE in winnt.h
-  * fixed bug in Vec4db constructor
+2015-07-31 버전 1.17
+  * Vec4uq에 대한 연산자 > 개선
+  * blend4q에 더 많은 특수 사례 추가
+  * nan_code 함수를 static inline으로 변경
+  * winnt.h의 BTYPE 매크로와의 충돌을 피하기 위해 수학 함수의 템플릿 매개변수 BTYPE를 BVTYPE로 변경
+  * Vec4db 생성자 버그 수정
 
-2014-10-24 version 1.16
-  * workaround for problem in Clang compiler extended to version 3.09 because not 
-      fixed yet by Clang (vectorf128.h line 134)
-  * recognize problem with Apple version of Clang reporting wrong version number
-  * remove various minor problems with Clang
-  * function pow(vector, int) modified to strengthen type checking and avoid compiler warnings
-  * manual discusses dynamic allocation of arrays of vectors
-  * various minor changes
+2014-10-24 버전 1.16
+  * Clang 컴파일러 문제에 대한 해결 방법을 버전 3.09로 확장 (Clang에서 아직 수정되지 않음, vectorf128.h 134행)
+  * 잘못된 버전 번호를 보고하는 Apple 버전의 Clang 문제 인식
+  * Clang 관련 다양한 사소한 문제 제거
+  * pow(vector, int) 함수를 수정하여 형식 검사를 강화하고 컴파일러 경고 방지
+  * 벡터 배열의 동적 할당에 대한 설명서 논의
+  * 다양한 사소한 변경 사항
 
-2014-10-17 version 1.15
-  * added files ranvec1.h and ranvec1.cpp for random number generator
-  * constructors to make boolean vectors from their elements
-  * constructors and = operators to broadcast boolean scalar into boolean vectors
-  * various lookup functions improved
-  * operators &, |, ^, ~, etc. defined for various boolean vectors to avoid converson
-      to integer vectors
-  * nmul_add functions
-  * mul_add etc. moved to main header files
-  * explicit fused multiply-and-add used in math functions to improve performance 
-      on compilers that don't automatically insert FMA
+2014-10-17 버전 1.15
+  * 난수 생성기를 위한 ranvec1.h 및 ranvec1.cpp 파일 추가
+  * 요소로부터 부울 벡터를 만드는 생성자
+  * 부울 스칼라를 부울 벡터로 브로드캐스트하는 생성자 및 = 연산자
+  * 다양한 조회 함수 개선
+  * 정수 벡터로의 변환을 피하기 위해 다양한 부울 벡터에 대해 정의된 연산자 &, |, ^, ~, 등
+  * nmul_add 함수
+  * mul_add 등을 주 헤더 파일로 이동
+  * FMA를 자동으로 삽입하지 않는 컴파일러에서 성능 향상을 위해 수학 함수에 명시적 융합 곱셈-덧셈 사용
 
-2014-07-24 version 1.14
-  * support for AVX-512f instruction set and 512-bit vectors:
-      Vec16i, Vec16ui, Vec8q, Vec8uq, Vec16f, Vec8d, and corresponding boolean vectors
-  * new define MAX_VECTOR_SIZE, valid values are 128, 256 and 512
-  * added hyperbolic functions sinh, cosh, tanh, asinh, acosh, atanh
-  * size() member function on all vector classes returns the number of elements
-  * functions for conversion between boolean vectors and integer bitfields
-  * extracting an element from a boolean vector now returns a bool, not an int
-  * improved precision in exp2 and exp10 functions
-  * various bug fixes
+2014-07-24 버전 1.14
+  * AVX-512f 명령어 세트 및 512비트 벡터 지원:
+      Vec16i, Vec16ui, Vec8q, Vec8uq, Vec16f, Vec8d 및 해당 부울 벡터
+  * 새로운 MAX_VECTOR_SIZE 정의, 유효한 값은 128, 256, 512
+  * 쌍곡선 함수 sinh, cosh, tanh, asinh, acosh, atanh 추가
+  * 모든 벡터 클래스의 size() 멤버 함수는 요소 수를 반환
+  * 부울 벡터와 정수 비트 필드 간 변환 함수
+  * 부울 벡터에서 요소를 추출하면 이제 int가 아닌 bool을 반환
+  * exp2 및 exp10 함수의 정밀도 향상
+  * 다양한 버그 수정
 
-2014-05-11 version 1.13
-  * pow function improved
-  * mul_add, mul_sub, mul_sub_x functions
-  * propagation of error codes through nan_code function
-  * "denormal" renamed to "subnormal" everywhere, in accordance with IEEE 754-2008 standard
+2014-05-11 버전 1.13
+  * pow 함수 개선
+  * mul_add, mul_sub, mul_sub_x 함수
+  * nan_code 함수를 통한 오류 코드 전파
+  * IEEE 754-2008 표준에 따라 모든 곳에서 "denormal"을 "subnormal"로 변경
 
-2014-04-20 version 1.12
-  * inline implementation of mathematical functions added (vectormath_exp.h vectormath_trig.h
+2014-04-20 버전 1.12
+  * 수학 함수의 인라인 구현 추가 (vectormath_exp.h vectormath_trig.h
       vectormath_common.h)
-  * vectormath.h renamed to vectormath_lib.h because a new alternative is added
-  * gather functions with constant indexes
-  * function sign_combine
-  * function pow_const(vector, const int)
-  * function pow_ratio(vector, const int, const int)
-  * functions horizontal_find_first, horizontal_count
-  * function recipr_sqrt removed
-  * functions round_to_int64_limited, truncate_to_int64_limited, to_double_limited
-  * function cubic_root renamed to cbrt
-  * function atan(vector,vector) renamed to atan2
-  * function if_mul
-  * function Vec4i round_to_int(Vec2d)
-  * operator & (float vector, boolean vector)
-  * operator &= (int vector, int vector)
-  * removed constructor Vec128b(int) and Vec256b(int) to avoid implicit conversion
-  * removed signalling nan function
-  * minor improvements in various blend and lookup functions
+  * 새로운 대안이 추가되어 vectormath.h를 vectormath_lib.h로 변경
+  * 상수 인덱스를 사용하는 수집 함수
+  * sign_combine 함수
+  * pow_const(vector, const int) 함수
+  * pow_ratio(vector, const int, const int) 함수
+  * horizontal_find_first, horizontal_count 함수
+  * recipr_sqrt 함수 제거
+  * round_to_int64_limited, truncate_to_int64_limited, to_double_limited 함수
+  * cubic_root 함수를 cbrt로 변경
+  * atan(vector,vector) 함수를 atan2로 변경
+  * if_mul 함수
+  * Vec4i round_to_int(Vec2d) 함수
+  * 연산자 & (float vector, boolean vector)
+  * 연산자 &= (int vector, int vector)
+  * 암시적 변환을 피하기 위해 Vec128b(int) 및 Vec256b(int) 생성자 제거
+  * 신호 nan 함수 제거
+  * 다양한 블렌드 및 조회 함수의 사소한 개선
 
-2014-03-01 version 1.11
-  * fixed missing unsigned operators >>= in vectori256.h
+2014-03-01 버전 1.11
+  * vectori256.h에서 누락된 부호 없는 연산자 >>= 수정
 
-2013-10-04 version 1.10
-  * clear distinction between boolean vectors and integer vectors for the sake of 
-      compatibility with mask registers in forthcoming AVX512 instruction set
-  * added function if_add
-  * tentative support for clang version 3.3 with workaround for bugs
-  * remove ambiguity for builtin m128i operator == in clang compiler. 
-  * problems in clang compiler, bug reports filed at clang
+2013-10-04 버전 1.10
+  * 향후 AVX512 명령어 세트의 마스크 레지스터와의 호환성을 위해 부울 벡터와 정수 벡터 명확히 구분
+  * if_add 함수 추가
+  * 버그 해결 방법과 함께 clang 버전 3.3 임시 지원
+  * clang 컴파일러에서 내장 m128i 연산자 == 모호성 제거
+  * clang 컴파일러 문제, clang에 버그 보고서 제출
       (http://llvm.org/bugs/show_bug.cgi?id=17164, 17312)
-  * instrset.h fixes problem with macros named min and max in MS windows.h
-  * workaround problem in MS Visual Studio 11.0. Bug report 735861 and 804274
-  * minor bug fixes
+  * instrset.h는 MS windows.h의 min 및 max 매크로 문제 해결
+  * MS Visual Studio 11.0 문제 해결 방법. 버그 보고서 735861 및 804274
+  * 사소한 버그 수정
 
-2013-03-31 version 1.03 beta
-  * bug fix for Vec2d cos (Vec2d const & x), VECTORMATH = 1
+2013-03-31 버전 1.03 베타
+  * Vec2d cos (Vec2d const & x), VECTORMATH = 1 버그 수정
 
-2012-08-01 version 1.02 beta
-  * added file vector3d.h for 3-dimensional vectors
-  * added file complexvec.h for complex numbers and complex vectors
-  * added file quaternion.h for quaternions
-  * added function change_sign for floating point vectors
-  * added operators +, -, *, / between floating point vectors and scalars to remove 
-      overloading ambiguity
+2012-08-01 버전 1.02 베타
+  * 3차원 벡터를 위한 vector3d.h 파일 추가
+  * 복소수 및 복소수 벡터를 위한 complexvec.h 파일 추가
+  * 쿼터니언을 위한 quaternion.h 파일 추가
+  * 부동 소수점 벡터에 대한 change_sign 함수 추가
+  * 오버로딩 모호성을 제거하기 위해 부동 소수점 벡터와 스칼라 간 연산자 +, -, *, / 추가
 
-2012-07-08 version 1.01 beta
-  * added file decimal.h with Number <-> string conversion functions: 
+2012-07-08 버전 1.01 베타
+  * 숫자 <-> 문자열 변환 함수가 있는 decimal.h 파일 추가:
       bin2bcd, bin2ascii, bin2hex_ascii, ascii2bin
-  * added andnot function for boolean vectors
-  * added functions shift_bytes_up and shift_bytes_down
-  * added operators for unsigned integer vector classes: >>=, &, &&, |, ||, ^, ~
-  * inteldispatchpatch.cpp removed. Use asmlib instead (www.agner.org/optimize/#asmlib)
-  * prefix ++ and -- operators now return a reference, postfix operators return a value
-  * various improvements in permute and blend functions
-  * minor improvement in abs function
-  * added version number to VECTORCLASS_H
+  * 부울 벡터에 대한 andnot 함수 추가
+  * shift_bytes_up 및 shift_bytes_down 함수 추가
+  * 부호 없는 정수 벡터 클래스에 대한 연산자 추가: >>=, &, &&, |, ||, ^, ~
+  * inteldispatchpatch.cpp 제거. 대신 asmlib 사용 (www.agner.org/optimize/#asmlib)
+  * 접두사 ++ 및 -- 연산자는 이제 참조를 반환하고 접미사 연산자는 값을 반환
+  * permute 및 blend 함수의 다양한 개선
+  * abs 함수의 사소한 개선
+  * VECTORCLASS_H에 버전 번호 추가
 
-2012-05-30 version 1.00 beta
-  * first public release
+2012-05-30 버전 1.00 베타
+  * 첫 공개 릴리스

--- a/yaml-cpp/CONTRIBUTING.md
+++ b/yaml-cpp/CONTRIBUTING.md
@@ -1,26 +1,23 @@
-# Style
+# 스타일
 
-This project is formatted with [clang-format][fmt] using the style file at the root of the repository. Please run clang-format before sending a pull request.
+이 프로젝트는 리포지토리 루트의 스타일 파일을 사용하여 [clang-format][fmt]으로 포맷됩니다. 풀 리퀘스트를 보내기 전에 clang-format을 실행하십시오.
 
-In general, try to follow the style of surrounding code. We mostly follow the [Google C++ style guide][cpp-style].
+일반적으로 주변 코드의 스타일을 따르십시오. 저희는 대부분 [Google C++ 스타일 가이드][cpp-style]를 따릅니다.
 
-Commit messages should be in the imperative mood, as described in the [Git contributing file][git-contrib]:
+커밋 메시지는 [Git 기여 파일][git-contrib]에 설명된 대로 명령형으로 작성해야 합니다.
 
-> Describe your changes in imperative mood, e.g. "make xyzzy do frotz"
-> instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy
-> to do frotz", as if you are giving orders to the codebase to change
-> its behaviour.
+> 변경 사항을 명령형으로 설명하십시오. 예를 들어 "[이 패치]는 xyzzy가 frotz를 하도록 만듭니다" 또는 "[나]는 xyzzy가 frotz를 하도록 변경했습니다" 대신 "xyzzy가 frotz를 하도록 만드십시오"와 같이 코드베이스에 동작 변경을 명령하는 것처럼 작성하십시오.
 
 [fmt]: http://clang.llvm.org/docs/ClangFormat.html
 [cpp-style]: https://google.github.io/styleguide/cppguide.html
 [git-contrib]: http://git.kernel.org/cgit/git/git.git/tree/Documentation/SubmittingPatches?id=HEAD
 
-# Tests
+# 테스트
 
-Please verify the tests pass by running the target `tests/run_tests`.
+`tests/run_tests` 대상을 실행하여 테스트가 통과하는지 확인하십시오.
 
-If you are adding functionality, add tests accordingly.
+기능을 추가하는 경우 그에 따라 테스트를 추가하십시오.
 
-# Pull request process
+# 풀 리퀘스트 프로세스
 
-Every pull request undergoes a code review. Unfortunately, github's code review process isn't great, but we'll manage. During the code review, if you make changes, add new commits to the pull request for each change. Once the code review is complete, rebase against the master branch and squash into a single commit.
+모든 풀 리퀘스트는 코드 검토를 거칩니다. 안타깝게도 github의 코드 검토 프로세스는 훌륭하지 않지만 저희는 관리할 것입니다. 코드 검토 중에 변경 사항이 있으면 각 변경 사항에 대해 풀 리퀘스트에 새 커밋을 추가하십시오. 코드 검토가 완료되면 마스터 브랜치에 대해 리베이스하고 단일 커밋으로 스쿼시하십시오.

--- a/yaml-cpp/README.md
+++ b/yaml-cpp/README.md
@@ -1,51 +1,51 @@
-# yaml-cpp [![Build Status](https://travis-ci.org/jbeder/yaml-cpp.svg?branch=master)](https://travis-ci.org/jbeder/yaml-cpp) [![Documentation](https://codedocs.xyz/jbeder/yaml-cpp.svg)](https://codedocs.xyz/jbeder/yaml-cpp/)
+# yaml-cpp [![빌드 상태](https://travis-ci.org/jbeder/yaml-cpp.svg?branch=master)](https://travis-ci.org/jbeder/yaml-cpp) [![문서](https://codedocs.xyz/jbeder/yaml-cpp.svg)](https://codedocs.xyz/jbeder/yaml-cpp/)
 
-yaml-cpp is a [YAML](http://www.yaml.org/) parser and emitter in C++ matching the [YAML 1.2 spec](http://www.yaml.org/spec/1.2/spec.html).
+yaml-cpp는 [YAML 1.2 사양](http://www.yaml.org/spec/1.2/spec.html)과 일치하는 C++용 [YAML](http://www.yaml.org/) 파서 및 이미터입니다.
 
-To get a feel for how it can be used, see the [Tutorial](https://github.com/jbeder/yaml-cpp/wiki/Tutorial) or [How to Emit YAML](https://github.com/jbeder/yaml-cpp/wiki/How-To-Emit-YAML). For the old API (version < 0.5.0), see [How To Parse A Document](https://github.com/jbeder/yaml-cpp/wiki/How-To-Parse-A-Document-(Old-API)).
+사용 방법에 대한 감을 잡으려면 [튜토리얼](https://github.com/jbeder/yaml-cpp/wiki/Tutorial) 또는 [YAML 방출 방법](https://github.com/jbeder/yaml-cpp/wiki/How-To-Emit-YAML)을 참조하십시오. 이전 API(버전 < 0.5.0)의 경우 [문서 구문 분석 방법 (이전 API)](https://github.com/jbeder/yaml-cpp/wiki/How-To-Parse-A-Document-(Old-API))을 참조하십시오.
 
-# Problems? #
+# 문제 있나요? #
 
-If you find a bug, post an [issue](https://github.com/jbeder/yaml-cpp/issues)! If you have questions about how to use yaml-cpp, please post it on http://stackoverflow.com and tag it [`yaml-cpp`](http://stackoverflow.com/questions/tagged/yaml-cpp).
+버그를 발견하면 [이슈](https://github.com/jbeder/yaml-cpp/issues)를 게시하십시오! yaml-cpp 사용 방법에 대한 질문이 있으면 http://stackoverflow.com에 게시하고 [`yaml-cpp`](http://stackoverflow.com/questions/tagged/yaml-cpp) 태그를 지정하십시오.
 
-# How to Build #
+# 빌드 방법 #
 
-yaml-cpp uses [CMake](http://www.cmake.org) to support cross-platform building. The basic steps to build are:
+yaml-cpp는 크로스 플랫폼 빌드를 지원하기 위해 [CMake](http://www.cmake.org)를 사용합니다. 기본 빌드 단계는 다음과 같습니다.
 
-1. Download and install [CMake](http://www.cmake.org) (Resources -> Download).
+1. [CMake](http://www.cmake.org) 다운로드 및 설치 (리소스 -> 다운로드).
 
-**Note:** If you don't use the provided installer for your platform, make sure that you add CMake's bin folder to your path.
+**참고:** 플랫폼에 제공된 설치 프로그램을 사용하지 않는 경우 CMake의 bin 폴더를 경로에 추가해야 합니다.
 
-2. Navigate into the source directory, and type:
+2. 소스 디렉토리로 이동하여 다음을 입력합니다.
 
 ```
 mkdir build
 cd build
 ```
 
-3. Run CMake. The basic syntax is:
+3. CMake를 실행합니다. 기본 구문은 다음과 같습니다.
 
 ```
-cmake [-G generator] [-DBUILD_SHARED_LIBS=ON|OFF] ..
+cmake [-G 생성기] [-DBUILD_SHARED_LIBS=ON|OFF] ..
 ```
 
-  * The `generator` is whatever type of build system you'd like to use. To see a full list of generators on your platform, just run `cmake` (with no arguments). For example:
-    * On Windows, you might use "Visual Studio 12 2013" to generate a Visual Studio 2013 solution or "Visual Studio 14 2015 Win64" to generate a 64-bit Visual Studio 2015 solution.
-    * On OS X, you might use "Xcode" to generate an Xcode project
-    * On a UNIX-y system, simply omit the option to generate a makefile
+  * `생성기`는 사용하려는 빌드 시스템 유형입니다. 플랫폼의 전체 생성기 목록을 보려면 `cmake` (인수 없음)를 실행하십시오. 예를 들어:
+    * Windows에서는 "Visual Studio 12 2013"을 사용하여 Visual Studio 2013 솔루션을 생성하거나 "Visual Studio 14 2015 Win64"를 사용하여 64비트 Visual Studio 2015 솔루션을 생성할 수 있습니다.
+    * OS X에서는 "Xcode"를 사용하여 Xcode 프로젝트를 생성할 수 있습니다.
+    * UNIX 계열 시스템에서는 옵션을 생략하여 makefile을 생성합니다.
 
-  * yaml-cpp defaults to building a static library, but you may build a shared library by specifying `-DBUILD_SHARED_LIBS=ON`.
+  * yaml-cpp는 기본적으로 정적 라이브러리를 빌드하지만 `-DBUILD_SHARED_LIBS=ON`을 지정하여 공유 라이브러리를 빌드할 수 있습니다.
 
-  * For more options on customizing the build, see the [CMakeLists.txt](https://github.com/jbeder/yaml-cpp/blob/master/CMakeLists.txt) file.
+  * 빌드 사용자 지정에 대한 자세한 옵션은 [CMakeLists.txt](https://github.com/jbeder/yaml-cpp/blob/master/CMakeLists.txt) 파일을 참조하십시오.
 
-4. Build it!
+4. 빌드하십시오!
 
-5. To clean up, just remove the `build` directory.
+5. 정리하려면 `build` 디렉토리를 제거하십시오.
 
-# Recent Release #
+# 최근 릴리스 #
 
-[yaml-cpp 0.6.0](https://github.com/jbeder/yaml-cpp/releases/tag/yaml-cpp-0.6.0) has been released! This release requires C++11, and no longer depends on Boost.
+[yaml-cpp 0.6.0](https://github.com/jbeder/yaml-cpp/releases/tag/yaml-cpp-0.6.0)이 릴리스되었습니다! 이 릴리스에는 C++11이 필요하며 더 이상 Boost에 의존하지 않습니다.
 
-[yaml-cpp 0.3.0](https://github.com/jbeder/yaml-cpp/releases/tag/release-0.3.0) is still available if you want the old API.
+이전 API를 원하면 [yaml-cpp 0.3.0](https://github.com/jbeder/yaml-cpp/releases/tag/release-0.3.0)을 계속 사용할 수 있습니다.
 
-**The old API will continue to be supported, and will still receive bugfixes!** The 0.3.x and 0.4.x versions will be old API releases, and 0.5.x and above will all be new API releases.
+**이전 API는 계속 지원되며 버그 수정도 계속 받을 것입니다!** 0.3.x 및 0.4.x 버전은 이전 API 릴리스이고 0.5.x 이상은 모두 새 API 릴리스입니다.

--- a/zlib-1.2.7/FAQ
+++ b/zlib-1.2.7/FAQ
@@ -1,368 +1,219 @@
-
-                Frequently Asked Questions about zlib
-
-
-If your question is not there, please check the zlib home page
-http://zlib.net/ which may have more recent information.
-The lastest zlib FAQ is at http://zlib.net/zlib_faq.html
+zlib에 대해 자주 묻는 질문
 
 
- 1. Is zlib Y2K-compliant?
+귀하의 질문이 없다면, 최신 정보가 있을 수 있는 zlib 홈페이지 http://zlib.net/를 확인하십시오.
+최신 zlib FAQ는 http://zlib.net/zlib_faq.html에 있습니다.
 
-    Yes. zlib doesn't handle dates.
 
- 2. Where can I get a Windows DLL version?
+ 1. zlib는 Y2K와 호환됩니까?
 
-    The zlib sources can be compiled without change to produce a DLL.  See the
-    file win32/DLL_FAQ.txt in the zlib distribution.  Pointers to the
-    precompiled DLL are found in the zlib web site at http://zlib.net/ .
+    예. zlib는 날짜를 처리하지 않습니다.
 
- 3. Where can I get a Visual Basic interface to zlib?
+ 2. Windows DLL 버전은 어디서 구할 수 있습니까?
 
-    See
+    zlib 소스는 변경 없이 컴파일하여 DLL을 생성할 수 있습니다. zlib 배포판의 win32/DLL_FAQ.txt 파일을 참조하십시오. 미리 컴파일된 DLL에 대한 포인터는 zlib 웹 사이트 http://zlib.net/에서 찾을 수 있습니다.
+
+ 3. zlib용 Visual Basic 인터페이스는 어디서 구할 수 있습니까?
+
+    다음을 참조하십시오.
         * http://marknelson.us/1997/01/01/zlib-engine/
-        * win32/DLL_FAQ.txt in the zlib distribution
+        * zlib 배포판의 win32/DLL_FAQ.txt
 
- 4. compress() returns Z_BUF_ERROR.
+ 4. compress()가 Z_BUF_ERROR를 반환합니다.
 
-    Make sure that before the call of compress(), the length of the compressed
-    buffer is equal to the available size of the compressed buffer and not
-    zero.  For Visual Basic, check that this parameter is passed by reference
-    ("as any"), not by value ("as long").
+    compress()를 호출하기 전에 압축된 버퍼의 길이가 압축된 버퍼의 사용 가능한 크기와 같고 0이 아닌지 확인하십시오. Visual Basic의 경우 이 매개변수가 값("as long")이 아닌 참조("as any")로 전달되는지 확인하십시오.
 
- 5. deflate() or inflate() returns Z_BUF_ERROR.
+ 5. deflate() 또는 inflate()가 Z_BUF_ERROR를 반환합니다.
 
-    Before making the call, make sure that avail_in and avail_out are not zero.
-    When setting the parameter flush equal to Z_FINISH, also make sure that
-    avail_out is big enough to allow processing all pending input.  Note that a
-    Z_BUF_ERROR is not fatal--another call to deflate() or inflate() can be
-    made with more input or output space.  A Z_BUF_ERROR may in fact be
-    unavoidable depending on how the functions are used, since it is not
-    possible to tell whether or not there is more output pending when
-    strm.avail_out returns with zero.  See http://zlib.net/zlib_how.html for a
-    heavily annotated example.
+    호출하기 전에 avail_in 및 avail_out이 0이 아닌지 확인하십시오. 매개변수 flush를 Z_FINISH로 설정할 때 avail_out이 보류 중인 모든 입력을 처리할 수 있을 만큼 충분히 큰지 확인하십시오. Z_BUF_ERROR는 치명적이지 않으며, 더 많은 입력 또는 출력 공간으로 deflate() 또는 inflate()를 다시 호출할 수 있습니다. strm.avail_out이 0으로 반환될 때 보류 중인 출력이 더 있는지 여부를 알 수 없으므로 함수 사용 방식에 따라 Z_BUF_ERROR가 실제로 불가피할 수 있습니다. 자세한 주석이 달린 예제는 http://zlib.net/zlib_how.html을 참조하십시오.
 
- 6. Where's the zlib documentation (man pages, etc.)?
+ 6. zlib 설명서(man 페이지 등)는 어디에 있습니까?
 
-    It's in zlib.h .  Examples of zlib usage are in the files test/example.c
-    and test/minigzip.c, with more in examples/ .
+    zlib.h에 있습니다. zlib 사용 예제는 test/example.c 및 test/minigzip.c 파일에 있으며, examples/ 디렉토리에 더 많은 예제가 있습니다.
 
- 7. Why don't you use GNU autoconf or libtool or ...?
+ 7. GNU autoconf나 libtool 등을 사용하지 않는 이유는 무엇입니까?
 
-    Because we would like to keep zlib as a very small and simple package.
-    zlib is rather portable and doesn't need much configuration.
+    zlib를 매우 작고 간단한 패키지로 유지하고 싶기 때문입니다. zlib는 상당히 이식성이 뛰어나며 많은 구성이 필요하지 않습니다.
 
- 8. I found a bug in zlib.
+ 8. zlib에서 버그를 발견했습니다.
 
-    Most of the time, such problems are due to an incorrect usage of zlib.
-    Please try to reproduce the problem with a small program and send the
-    corresponding source to us at zlib@gzip.org .  Do not send multi-megabyte
-    data files without prior agreement.
+    대부분의 경우 이러한 문제는 zlib의 잘못된 사용으로 인해 발생합니다. 작은 프로그램으로 문제를 재현하고 해당 소스를 zlib@gzip.org로 보내주십시오. 사전 동의 없이 수 메가바이트의 데이터 파일을 보내지 마십시오.
 
- 9. Why do I get "undefined reference to gzputc"?
+ 9. "undefined reference to gzputc"라는 메시지가 나타나는 이유는 무엇입니까?
 
-    If "make test" produces something like
+    "make test"가 다음과 같은 결과를 생성하는 경우
 
        example.o(.text+0x154): undefined reference to `gzputc'
 
-    check that you don't have old files libz.* in /usr/lib, /usr/local/lib or
-    /usr/X11R6/lib. Remove any old versions, then do "make install".
+    /usr/lib, /usr/local/lib 또는 /usr/X11R6/lib에 이전 libz.* 파일이 없는지 확인하십시오. 이전 버전을 제거한 다음 "make install"을 실행하십시오.
 
-10. I need a Delphi interface to zlib.
+10. zlib용 Delphi 인터페이스가 필요합니다.
 
-    See the contrib/delphi directory in the zlib distribution.
+    zlib 배포판의 contrib/delphi 디렉토리를 참조하십시오.
 
-11. Can zlib handle .zip archives?
+11. zlib가 .zip 아카이브를 처리할 수 있습니까?
 
-    Not by itself, no.  See the directory contrib/minizip in the zlib
-    distribution.
+    자체적으로는 처리할 수 없습니다. zlib 배포판의 contrib/minizip 디렉토리를 참조하십시오.
 
-12. Can zlib handle .Z files?
+12. zlib가 .Z 파일을 처리할 수 있습니까?
 
-    No, sorry.  You have to spawn an uncompress or gunzip subprocess, or adapt
-    the code of uncompress on your own.
+    아니요, 죄송합니다. uncompress 또는 gunzip 하위 프로세스를 생성하거나 직접 uncompress 코드를 수정해야 합니다.
 
-13. How can I make a Unix shared library?
+13. Unix 공유 라이브러리는 어떻게 만듭니까?
 
-    By default a shared (and a static) library is built for Unix.  So:
+    기본적으로 Unix용 공유 (및 정적) 라이브러리가 빌드됩니다. 따라서:
 
     make distclean
     ./configure
     make
 
-14. How do I install a shared zlib library on Unix?
+14. Unix에 공유 zlib 라이브러리를 어떻게 설치합니까?
 
-    After the above, then:
+    위의 작업을 수행한 후 다음을 실행합니다.
 
     make install
 
-    However, many flavors of Unix come with a shared zlib already installed.
-    Before going to the trouble of compiling a shared version of zlib and
-    trying to install it, you may want to check if it's already there!  If you
-    can #include <zlib.h>, it's there.  The -lz option will probably link to
-    it.  You can check the version at the top of zlib.h or with the
-    ZLIB_VERSION symbol defined in zlib.h .
+    그러나 많은 Unix 계열에는 이미 공유 zlib가 설치되어 있습니다. 공유 버전의 zlib를 컴파일하고 설치하려고 하기 전에 이미 설치되어 있는지 확인하는 것이 좋습니다! #include <zlib.h>를 사용할 수 있다면 설치되어 있는 것입니다. -lz 옵션은 아마도 해당 라이브러리에 링크될 것입니다. zlib.h 상단이나 zlib.h에 정의된 ZLIB_VERSION 기호로 버전을 확인할 수 있습니다.
 
-15. I have a question about OttoPDF.
+15. OttoPDF에 대한 질문이 있습니다.
 
-    We are not the authors of OttoPDF. The real author is on the OttoPDF web
-    site: Joel Hainley, jhainley@myndkryme.com.
+    저희는 OttoPDF의 저자가 아닙니다. 실제 저자는 OttoPDF 웹 사이트에 있습니다: Joel Hainley, jhainley@myndkryme.com.
 
-16. Can zlib decode Flate data in an Adobe PDF file?
+16. zlib가 Adobe PDF 파일의 Flate 데이터를 디코딩할 수 있습니까?
 
-    Yes. See http://www.pdflib.com/ . To modify PDF forms, see
-    http://sourceforge.net/projects/acroformtool/ .
+    예. http://www.pdflib.com/을 참조하십시오. PDF 양식을 수정하려면 http://sourceforge.net/projects/acroformtool/을 참조하십시오.
 
-17. Why am I getting this "register_frame_info not found" error on Solaris?
+17. Solaris에서 "register_frame_info not found" 오류가 나타나는 이유는 무엇입니까?
 
-    After installing zlib 1.1.4 on Solaris 2.6, running applications using zlib
-    generates an error such as:
+    Solaris 2.6에 zlib 1.1.4를 설치한 후 zlib를 사용하는 응용 프로그램을 실행하면 다음과 같은 오류가 발생합니다.
 
         ld.so.1: rpm: fatal: relocation error: file /usr/local/lib/libz.so:
         symbol __register_frame_info: referenced symbol not found
 
-    The symbol __register_frame_info is not part of zlib, it is generated by
-    the C compiler (cc or gcc).  You must recompile applications using zlib
-    which have this problem.  This problem is specific to Solaris.  See
-    http://www.sunfreeware.com for Solaris versions of zlib and applications
-    using zlib.
+    기호 __register_frame_info는 zlib의 일부가 아니며 C 컴파일러(cc 또는 gcc)에 의해 생성됩니다. 이 문제가 있는 zlib를 사용하는 응용 프로그램을 다시 컴파일해야 합니다. 이 문제는 Solaris에만 해당됩니다. zlib 및 zlib를 사용하는 응용 프로그램의 Solaris 버전은 http://www.sunfreeware.com을 참조하십시오.
 
-18. Why does gzip give an error on a file I make with compress/deflate?
+18. compress/deflate로 만든 파일에서 gzip이 오류를 발생시키는 이유는 무엇입니까?
 
-    The compress and deflate functions produce data in the zlib format, which
-    is different and incompatible with the gzip format.  The gz* functions in
-    zlib on the other hand use the gzip format.  Both the zlib and gzip formats
-    use the same compressed data format internally, but have different headers
-    and trailers around the compressed data.
+    compress 및 deflate 함수는 zlib 형식의 데이터를 생성하며, 이는 gzip 형식과 다르고 호환되지 않습니다. 반면에 zlib의 gz* 함수는 gzip 형식을 사용합니다. zlib 및 gzip 형식 모두 내부적으로 동일한 압축 데이터 형식을 사용하지만 압축된 데이터 주위에 다른 헤더와 트레일러가 있습니다.
 
-19. Ok, so why are there two different formats?
+19. 그렇다면 왜 두 가지 다른 형식이 있습니까?
 
-    The gzip format was designed to retain the directory information about a
-    single file, such as the name and last modification date.  The zlib format
-    on the other hand was designed for in-memory and communication channel
-    applications, and has a much more compact header and trailer and uses a
-    faster integrity check than gzip.
+    gzip 형식은 이름 및 마지막 수정 날짜와 같은 단일 파일에 대한 디렉토리 정보를 유지하도록 설계되었습니다. 반면에 zlib 형식은 메모리 내 및 통신 채널 응용 프로그램을 위해 설계되었으며 훨씬 더 간결한 헤더와 트레일러를 사용하고 gzip보다 빠른 무결성 검사를 사용합니다.
 
-20. Well that's nice, but how do I make a gzip file in memory?
+20. 좋습니다. 하지만 메모리에서 gzip 파일을 어떻게 만듭니까?
 
-    You can request that deflate write the gzip format instead of the zlib
-    format using deflateInit2().  You can also request that inflate decode the
-    gzip format using inflateInit2().  Read zlib.h for more details.
+    deflateInit2()를 사용하여 deflate가 zlib 형식 대신 gzip 형식을 작성하도록 요청할 수 있습니다. 또한 inflateInit2()를 사용하여 inflate가 gzip 형식을 디코딩하도록 요청할 수 있습니다. 자세한 내용은 zlib.h를 읽어보십시오.
 
-21. Is zlib thread-safe?
+21. zlib는 스레드로부터 안전합니까?
 
-    Yes.  However any library routines that zlib uses and any application-
-    provided memory allocation routines must also be thread-safe.  zlib's gz*
-    functions use stdio library routines, and most of zlib's functions use the
-    library memory allocation routines by default.  zlib's *Init* functions
-    allow for the application to provide custom memory allocation routines.
+    예. 그러나 zlib가 사용하는 모든 라이브러리 루틴과 응용 프로그램에서 제공하는 모든 메모리 할당 루틴도 스레드로부터 안전해야 합니다. zlib의 gz* 함수는 stdio 라이브러리 루틴을 사용하며, 대부분의 zlib 함수는 기본적으로 라이브러리 메모리 할당 루틴을 사용합니다. zlib의 *Init* 함수를 사용하면 응용 프로그램에서 사용자 지정 메모리 할당 루틴을 제공할 수 있습니다.
 
-    Of course, you should only operate on any given zlib or gzip stream from a
-    single thread at a time.
+    물론 특정 zlib 또는 gzip 스트림은 한 번에 단일 스레드에서만 작동해야 합니다.
 
-22. Can I use zlib in my commercial application?
+22. 상용 응용 프로그램에서 zlib를 사용할 수 있습니까?
 
-    Yes.  Please read the license in zlib.h.
+    예. zlib.h의 라이선스를 읽어보십시오.
 
-23. Is zlib under the GNU license?
+23. zlib는 GNU 라이선스 하에 있습니까?
 
-    No.  Please read the license in zlib.h.
+    아니요. zlib.h의 라이선스를 읽어보십시오.
 
-24. The license says that altered source versions must be "plainly marked". So
-    what exactly do I need to do to meet that requirement?
+24. 라이선스에는 변경된 소스 버전은 "명확하게 표시"되어야 한다고 명시되어 있습니다. 그렇다면 해당 요구 사항을 충족하려면 정확히 무엇을 해야 합니까?
 
-    You need to change the ZLIB_VERSION and ZLIB_VERNUM #defines in zlib.h.  In
-    particular, the final version number needs to be changed to "f", and an
-    identification string should be appended to ZLIB_VERSION.  Version numbers
-    x.x.x.f are reserved for modifications to zlib by others than the zlib
-    maintainers.  For example, if the version of the base zlib you are altering
-    is "1.2.3.4", then in zlib.h you should change ZLIB_VERNUM to 0x123f, and
-    ZLIB_VERSION to something like "1.2.3.f-zachary-mods-v3".  You can also
-    update the version strings in deflate.c and inftrees.c.
+    zlib.h의 ZLIB_VERSION 및 ZLIB_VERNUM #define을 변경해야 합니다. 특히 최종 버전 번호는 "f"로 변경해야 하며 ZLIB_VERSION에 식별 문자열을 추가해야 합니다. 버전 번호 x.x.x.f는 zlib 유지 관리자가 아닌 다른 사람이 zlib를 수정한 경우에 사용됩니다. 예를 들어 변경하는 기본 zlib의 버전이 "1.2.3.4"인 경우 zlib.h에서 ZLIB_VERNUM을 0x123f로 변경하고 ZLIB_VERSION을 "1.2.3.f-zachary-mods-v3"과 같이 변경해야 합니다. deflate.c 및 inftrees.c의 버전 문자열도 업데이트할 수 있습니다.
 
-    For altered source distributions, you should also note the origin and
-    nature of the changes in zlib.h, as well as in ChangeLog and README, along
-    with the dates of the alterations.  The origin should include at least your
-    name (or your company's name), and an email address to contact for help or
-    issues with the library.
+    변경된 소스 배포의 경우 변경 날짜와 함께 zlib.h, ChangeLog 및 README에 변경 사항의 출처와 특성을 기록해야 합니다. 출처에는 최소한 귀하의 이름(또는 회사 이름)과 라이브러리 관련 도움이나 문제에 대한 문의 이메일 주소가 포함되어야 합니다.
 
-    Note that distributing a compiled zlib library along with zlib.h and
-    zconf.h is also a source distribution, and so you should change
-    ZLIB_VERSION and ZLIB_VERNUM and note the origin and nature of the changes
-    in zlib.h as you would for a full source distribution.
+    컴파일된 zlib 라이브러리를 zlib.h 및 zconf.h와 함께 배포하는 것도 소스 배포이므로 전체 소스 배포와 마찬가지로 ZLIB_VERSION 및 ZLIB_VERNUM을 변경하고 zlib.h에 변경 사항의 출처와 특성을 기록해야 합니다.
 
-25. Will zlib work on a big-endian or little-endian architecture, and can I
-    exchange compressed data between them?
+25. zlib는 빅 엔디안 또는 리틀 엔디안 아키텍처에서 작동합니까? 그리고 그들 사이에서 압축된 데이터를 교환할 수 있습니까?
 
-    Yes and yes.
+    예, 그리고 예.
 
-26. Will zlib work on a 64-bit machine?
+26. zlib는 64비트 시스템에서 작동합니까?
 
-    Yes.  It has been tested on 64-bit machines, and has no dependence on any
-    data types being limited to 32-bits in length.  If you have any
-    difficulties, please provide a complete problem report to zlib@gzip.org
+    예. 64비트 시스템에서 테스트되었으며 데이터 형식이 32비트로 제한되는 것에 의존하지 않습니다. 어려움이 있으면 zlib@gzip.org로 전체 문제 보고서를 제공하십시오.
 
-27. Will zlib decompress data from the PKWare Data Compression Library?
+27. zlib가 PKWare 데이터 압축 라이브러리의 데이터를 압축 해제할 수 있습니까?
 
-    No.  The PKWare DCL uses a completely different compressed data format than
-    does PKZIP and zlib.  However, you can look in zlib's contrib/blast
-    directory for a possible solution to your problem.
+    아니요. PKWare DCL은 PKZIP 및 zlib와 완전히 다른 압축 데이터 형식을 사용합니다. 그러나 문제에 대한 가능한 해결책은 zlib의 contrib/blast 디렉토리를 참조하십시오.
 
-28. Can I access data randomly in a compressed stream?
+28. 압축된 스트림에서 데이터에 무작위로 액세스할 수 있습니까?
 
-    No, not without some preparation.  If when compressing you periodically use
-    Z_FULL_FLUSH, carefully write all the pending data at those points, and
-    keep an index of those locations, then you can start decompression at those
-    points.  You have to be careful to not use Z_FULL_FLUSH too often, since it
-    can significantly degrade compression.  Alternatively, you can scan a
-    deflate stream once to generate an index, and then use that index for
-    random access.  See examples/zran.c .
+    아니요, 약간의 준비 없이는 불가능합니다. 압축할 때 주기적으로 Z_FULL_FLUSH를 사용하고 해당 지점에서 보류 중인 모든 데이터를 신중하게 쓰고 해당 위치의 인덱스를 유지하면 해당 지점에서 압축 해제를 시작할 수 있습니다. Z_FULL_FLUSH를 너무 자주 사용하면 압축률이 크게 저하될 수 있으므로 주의해야 합니다. 또는 deflate 스트림을 한 번 스캔하여 인덱스를 생성한 다음 해당 인덱스를 사용하여 무작위 액세스할 수 있습니다. examples/zran.c를 참조하십시오.
 
-29. Does zlib work on MVS, OS/390, CICS, etc.?
+29. zlib는 MVS, OS/390, CICS 등에서 작동합니까?
 
-    It has in the past, but we have not heard of any recent evidence.  There
-    were working ports of zlib 1.1.4 to MVS, but those links no longer work.
-    If you know of recent, successful applications of zlib on these operating
-    systems, please let us know.  Thanks.
+    과거에는 작동했지만 최근 증거는 듣지 못했습니다. MVS용 zlib 1.1.4의 작동 포트가 있었지만 해당 링크는 더 이상 작동하지 않습니다. 이러한 운영 체제에서 zlib를 최근 성공적으로 적용한 사례를 알고 있다면 알려주십시오. 감사합니다.
 
-30. Is there some simpler, easier to read version of inflate I can look at to
-    understand the deflate format?
+30. deflate 형식을 이해하기 위해 살펴볼 수 있는 더 간단하고 읽기 쉬운 inflate 버전이 있습니까?
 
-    First off, you should read RFC 1951.  Second, yes.  Look in zlib's
-    contrib/puff directory.
+    먼저 RFC 1951을 읽어야 합니다. 둘째, 예. zlib의 contrib/puff 디렉토리를 참조하십시오.
 
-31. Does zlib infringe on any patents?
+31. zlib가 특허를 침해합니까?
 
-    As far as we know, no.  In fact, that was originally the whole point behind
-    zlib.  Look here for some more information:
+    저희가 아는 한, 아니요. 사실, 그것이 원래 zlib의 전부였습니다. 자세한 내용은 다음을 참조하십시오.
 
     http://www.gzip.org/#faq11
 
-32. Can zlib work with greater than 4 GB of data?
+32. zlib가 4GB보다 큰 데이터를 처리할 수 있습니까?
 
-    Yes.  inflate() and deflate() will process any amount of data correctly.
-    Each call of inflate() or deflate() is limited to input and output chunks
-    of the maximum value that can be stored in the compiler's "unsigned int"
-    type, but there is no limit to the number of chunks.  Note however that the
-    strm.total_in and strm_total_out counters may be limited to 4 GB.  These
-    counters are provided as a convenience and are not used internally by
-    inflate() or deflate().  The application can easily set up its own counters
-    updated after each call of inflate() or deflate() to count beyond 4 GB.
-    compress() and uncompress() may be limited to 4 GB, since they operate in a
-    single call.  gzseek() and gztell() may be limited to 4 GB depending on how
-    zlib is compiled.  See the zlibCompileFlags() function in zlib.h.
+    예. inflate() 및 deflate()는 모든 양의 데이터를 올바르게 처리합니다. 각 inflate() 또는 deflate() 호출은 컴파일러의 "unsigned int" 유형에 저장할 수 있는 최대값의 입력 및 출력 청크로 제한되지만 청크 수에는 제한이 없습니다. 그러나 strm.total_in 및 strm_total_out 카운터는 4GB로 제한될 수 있습니다. 이러한 카운터는 편의를 위해 제공되며 inflate() 또는 deflate()에서 내부적으로 사용되지 않습니다. 응용 프로그램은 각 inflate() 또는 deflate() 호출 후 업데이트되는 자체 카운터를 쉽게 설정하여 4GB를 초과하여 계산할 수 있습니다. compress() 및 uncompress()는 단일 호출로 작동하므로 4GB로 제한될 수 있습니다. gzseek() 및 gztell()은 zlib 컴파일 방식에 따라 4GB로 제한될 수 있습니다. zlib.h의 zlibCompileFlags() 함수를 참조하십시오.
 
-    The word "may" appears several times above since there is a 4 GB limit only
-    if the compiler's "long" type is 32 bits.  If the compiler's "long" type is
-    64 bits, then the limit is 16 exabytes.
+    컴파일러의 "long" 유형이 32비트인 경우에만 4GB 제한이 있으므로 위에서 "may"라는 단어가 여러 번 나타납니다. 컴파일러의 "long" 유형이 64비트이면 제한은 16엑사바이트입니다.
 
-33. Does zlib have any security vulnerabilities?
+33. zlib에 보안 취약점이 있습니까?
 
-    The only one that we are aware of is potentially in gzprintf().  If zlib is
-    compiled to use sprintf() or vsprintf(), then there is no protection
-    against a buffer overflow of an 8K string space (or other value as set by
-    gzbuffer()), other than the caller of gzprintf() assuring that the output
-    will not exceed 8K.  On the other hand, if zlib is compiled to use
-    snprintf() or vsnprintf(), which should normally be the case, then there is
-    no vulnerability.  The ./configure script will display warnings if an
-    insecure variation of sprintf() will be used by gzprintf().  Also the
-    zlibCompileFlags() function will return information on what variant of
-    sprintf() is used by gzprintf().
+    저희가 아는 유일한 취약점은 잠재적으로 gzprintf()에 있습니다. zlib가 sprintf() 또는 vsprintf()를 사용하도록 컴파일된 경우 gzprintf() 호출자가 출력이 8K를 초과하지 않도록 보장하는 것 외에는 8K 문자열 공간(또는 gzbuffer()에서 설정한 다른 값)의 버퍼 오버플로에 대한 보호가 없습니다. 반면에 zlib가 일반적으로 그래야 하는 snprintf() 또는 vsnprintf()를 사용하도록 컴파일된 경우 취약점이 없습니다. ./configure 스크립트는 gzprintf()에서 안전하지 않은 sprintf() 변형이 사용될 경우 경고를 표시합니다. 또한 zlibCompileFlags() 함수는 gzprintf()에서 사용하는 sprintf() 변형에 대한 정보를 반환합니다.
 
-    If you don't have snprintf() or vsnprintf() and would like one, you can
-    find a portable implementation here:
+    snprintf() 또는 vsnprintf()가 없고 하나를 원한다면 다음에서 이식 가능한 구현을 찾을 수 있습니다.
 
         http://www.ijs.si/software/snprintf/
 
-    Note that you should be using the most recent version of zlib.  Versions
-    1.1.3 and before were subject to a double-free vulnerability, and versions
-    1.2.1 and 1.2.2 were subject to an access exception when decompressing
-    invalid compressed data.
+    최신 버전의 zlib를 사용해야 합니다. 버전 1.1.3 이전 버전은 이중 해제 취약점에 취약했으며 버전 1.2.1 및 1.2.2는 잘못된 압축 데이터를 압축 해제할 때 액세스 예외에 취약했습니다.
 
-34. Is there a Java version of zlib?
+34. zlib의 Java 버전이 있습니까?
 
-    Probably what you want is to use zlib in Java. zlib is already included
-    as part of the Java SDK in the java.util.zip package. If you really want
-    a version of zlib written in the Java language, look on the zlib home
-    page for links: http://zlib.net/ .
+    아마도 Java에서 zlib를 사용하고 싶을 것입니다. zlib는 이미 java.util.zip 패키지의 Java SDK의 일부로 포함되어 있습니다. Java 언어로 작성된 zlib 버전을 정말로 원한다면 zlib 홈페이지에서 링크를 찾아보십시오: http://zlib.net/ .
 
-35. I get this or that compiler or source-code scanner warning when I crank it
-    up to maximally-pedantic. Can't you guys write proper code?
+35. 최대한 꼼꼼하게 컴파일러나 소스 코드 스캐너 경고를 올렸을 때 이런저런 경고가 나타납니다. 제대로 된 코드를 작성할 수 없습니까?
 
-    Many years ago, we gave up attempting to avoid warnings on every compiler
-    in the universe.  It just got to be a waste of time, and some compilers
-    were downright silly as well as contradicted each other.  So now, we simply
-    make sure that the code always works.
+    몇 년 전에 저희는 우주의 모든 컴파일러에서 경고를 피하려는 시도를 포기했습니다. 시간 낭비였고 일부 컴파일러는 완전히 어리석었을 뿐만 아니라 서로 모순되었습니다. 그래서 이제 저희는 코드가 항상 작동하도록 합니다.
 
-36. Valgrind (or some similar memory access checker) says that deflate is
-    performing a conditional jump that depends on an uninitialized value.
-    Isn't that a bug?
+36. Valgrind(또는 유사한 메모리 액세스 검사기)는 deflate가 초기화되지 않은 값에 의존하는 조건부 점프를 수행한다고 말합니다. 버그가 아닙니까?
 
-    No.  That is intentional for performance reasons, and the output of deflate
-    is not affected.  This only started showing up recently since zlib 1.2.x
-    uses malloc() by default for allocations, whereas earlier versions used
-    calloc(), which zeros out the allocated memory.  Even though the code was
-    correct, versions 1.2.4 and later was changed to not stimulate these
-    checkers.
+    아니요. 성능상의 이유로 의도적인 것이며 deflate의 출력에는 영향을 미치지 않습니다. 이는 zlib 1.2.x가 기본적으로 할당에 malloc()을 사용하는 반면 이전 버전은 할당된 메모리를 0으로 채우는 calloc()을 사용했기 때문에 최근에야 나타나기 시작했습니다. 코드가 정확했지만 버전 1.2.4 이상은 이러한 검사기를 자극하지 않도록 변경되었습니다.
 
-37. Will zlib read the (insert any ancient or arcane format here) compressed
-    data format?
+37. zlib가 (여기에 고대 또는 난해한 형식 삽입) 압축 데이터 형식을 읽을 수 있습니까?
 
-    Probably not. Look in the comp.compression FAQ for pointers to various
-    formats and associated software.
+    아마도 아닐 것입니다. 다양한 형식 및 관련 소프트웨어에 대한 포인터는 comp.compression FAQ를 참조하십시오.
 
-38. How can I encrypt/decrypt zip files with zlib?
+38. zlib로 zip 파일을 암호화/복호화하려면 어떻게 해야 합니까?
 
-    zlib doesn't support encryption.  The original PKZIP encryption is very
-    weak and can be broken with freely available programs.  To get strong
-    encryption, use GnuPG, http://www.gnupg.org/ , which already includes zlib
-    compression.  For PKZIP compatible "encryption", look at
-    http://www.info-zip.org/
+    zlib는 암호화를 지원하지 않습니다. 원래 PKZIP 암호화는 매우 약하며 무료로 제공되는 프로그램으로 해독할 수 있습니다. 강력한 암호화를 얻으려면 이미 zlib 압축을 포함하는 GnuPG, http://www.gnupg.org/를 사용하십시오. PKZIP 호환 "암호화"의 경우 http://www.info-zip.org/를 참조하십시오.
 
-39. What's the difference between the "gzip" and "deflate" HTTP 1.1 encodings?
+39. "gzip"과 "deflate" HTTP 1.1 인코딩의 차이점은 무엇입니까?
 
-    "gzip" is the gzip format, and "deflate" is the zlib format.  They should
-    probably have called the second one "zlib" instead to avoid confusion with
-    the raw deflate compressed data format.  While the HTTP 1.1 RFC 2616
-    correctly points to the zlib specification in RFC 1950 for the "deflate"
-    transfer encoding, there have been reports of servers and browsers that
-    incorrectly produce or expect raw deflate data per the deflate
-    specification in RFC 1951, most notably Microsoft.  So even though the
-    "deflate" transfer encoding using the zlib format would be the more
-    efficient approach (and in fact exactly what the zlib format was designed
-    for), using the "gzip" transfer encoding is probably more reliable due to
-    an unfortunate choice of name on the part of the HTTP 1.1 authors.
+    "gzip"은 gzip 형식이고 "deflate"는 zlib 형식입니다. 원시 deflate 압축 데이터 형식과의 혼동을 피하기 위해 두 번째 형식을 "zlib"라고 불렀어야 합니다. HTTP 1.1 RFC 2616은 "deflate" 전송 인코딩에 대해 RFC 1950의 zlib 사양을 올바르게 가리키지만, RFC 1951의 deflate 사양에 따라 원시 deflate 데이터를 잘못 생성하거나 예상하는 서버 및 브라우저, 특히 Microsoft에 대한 보고가 있었습니다. 따라서 zlib 형식을 사용하는 "deflate" 전송 인코딩이 더 효율적인 접근 방식(실제로 zlib 형식이 설계된 목적)이겠지만, HTTP 1.1 작성자의 불행한 이름 선택으로 인해 "gzip" 전송 인코딩을 사용하는 것이 아마도 더 안정적일 것입니다.
 
-    Bottom line: use the gzip format for HTTP 1.1 encoding.
+    결론: HTTP 1.1 인코딩에는 gzip 형식을 사용하십시오.
 
-40. Does zlib support the new "Deflate64" format introduced by PKWare?
+40. zlib가 PKWare에서 도입한 새로운 "Deflate64" 형식을 지원합니까?
 
-    No.  PKWare has apparently decided to keep that format proprietary, since
-    they have not documented it as they have previous compression formats.  In
-    any case, the compression improvements are so modest compared to other more
-    modern approaches, that it's not worth the effort to implement.
+    아니요. PKWare는 이전 압축 형식과 마찬가지로 문서화하지 않았기 때문에 해당 형식을 독점적으로 유지하기로 결정한 것 같습니다. 어쨌든 압축 개선은 다른 최신 접근 방식에 비해 너무 미미하여 구현할 가치가 없습니다.
 
-41. I'm having a problem with the zip functions in zlib, can you help?
+41. zlib의 zip 함수에 문제가 있는데 도와주실 수 있습니까?
 
-    There are no zip functions in zlib.  You are probably using minizip by
-    Giles Vollant, which is found in the contrib directory of zlib.  It is not
-    part of zlib.  In fact none of the stuff in contrib is part of zlib.  The
-    files in there are not supported by the zlib authors.  You need to contact
-    the authors of the respective contribution for help.
+    zlib에는 zip 함수가 없습니다. 아마도 zlib의 contrib 디렉토리에 있는 Giles Vollant의 minizip을 사용하고 있을 것입니다. 이것은 zlib의 일부가 아닙니다. 사실 contrib의 어떤 것도 zlib의 일부가 아닙니다. 해당 파일은 zlib 작성자가 지원하지 않습니다. 도움을 받으려면 각 기여 작성자에게 문의해야 합니다.
 
-42. The match.asm code in contrib is under the GNU General Public License.
-    Since it's part of zlib, doesn't that mean that all of zlib falls under the
-    GNU GPL?
+42. contrib의 match.asm 코드는 GNU 일반 공중 사용 허가서 하에 있습니다. zlib의 일부이므로 모든 zlib가 GNU GPL 하에 있다는 의미가 아닙니까?
 
-    No.  The files in contrib are not part of zlib.  They were contributed by
-    other authors and are provided as a convenience to the user within the zlib
-    distribution.  Each item in contrib has its own license.
+    아니요. contrib의 파일은 zlib의 일부가 아닙니다. 다른 작성자가 기여했으며 zlib 배포판 내에서 사용자의 편의를 위해 제공됩니다. contrib의 각 항목에는 자체 라이선스가 있습니다.
 
-43. Is zlib subject to export controls?  What is its ECCN?
+43. zlib는 수출 통제 대상입니까? ECCN은 무엇입니까?
 
-    zlib is not subject to export controls, and so is classified as EAR99.
+    zlib는 수출 통제 대상이 아니므로 EAR99로 분류됩니다.
 
-44. Can you please sign these lengthy legal documents and fax them back to us
-    so that we can use your software in our product?
+44. 저희 제품에서 귀하의 소프트웨어를 사용할 수 있도록 이 장황한 법적 문서에 서명하고 팩스로 보내주시겠습니까?
 
-    No. Go away. Shoo.
+    아니요. 가십시오. 저리 가십시오.

--- a/zlib-1.2.7/README
+++ b/zlib-1.2.7/README
@@ -1,115 +1,68 @@
-ZLIB DATA COMPRESSION LIBRARY
+ZLIB 데이터 압축 라이브러리
 
-zlib 1.2.7 is a general purpose data compression library.  All the code is
-thread safe.  The data format used by the zlib library is described by RFCs
-(Request for Comments) 1950 to 1952 in the files
-http://tools.ietf.org/html/rfc1950 (zlib format), rfc1951 (deflate format) and
-rfc1952 (gzip format).
+zlib 1.2.7은 범용 데이터 압축 라이브러리입니다. 모든 코드는 스레드로부터 안전합니다. zlib 라이브러리에서 사용하는 데이터 형식은 RFC(Request for Comments) 1950부터 1952까지의 문서에 설명되어 있으며, 해당 파일은 http://tools.ietf.org/html/rfc1950 (zlib 형식), rfc1951 (deflate 형식) 및 rfc1952 (gzip 형식)에서 확인할 수 있습니다.
 
-All functions of the compression library are documented in the file zlib.h
-(volunteer to write man pages welcome, contact zlib@gzip.org).  A usage example
-of the library is given in the file test/example.c which also tests that
-the library is working correctly.  Another example is given in the file
-test/minigzip.c.  The compression library itself is composed of all source
-files in the root directory.
+압축 라이브러리의 모든 함수는 zlib.h 파일에 문서화되어 있습니다 (man 페이지 작성 자원봉사자는 zlib@gzip.org로 연락 바랍니다). 라이브러리 사용 예제는 test/example.c 파일에 있으며, 이 파일은 라이브러리가 올바르게 작동하는지도 테스트합니다. 또 다른 예제는 test/minigzip.c 파일에 있습니다. 압축 라이브러리 자체는 루트 디렉토리의 모든 소스 파일로 구성됩니다.
 
-To compile all files and run the test program, follow the instructions given at
-the top of Makefile.in.  In short "./configure; make test", and if that goes
-well, "make install" should work for most flavors of Unix.  For Windows, use
-one of the special makefiles in win32/ or contrib/vstudio/ .  For VMS, use
-make_vms.com.
+모든 파일을 컴파일하고 테스트 프로그램을 실행하려면 Makefile.in 상단에 있는 지침을 따르십시오. 간단히 말해 "./configure; make test"를 실행하고, 이것이 잘 되면 대부분의 유닉스 계열에서 "make install"이 작동합니다. Windows의 경우 win32/ 또는 contrib/vstudio/ 디렉토리의 특수 makefile 중 하나를 사용하십시오. VMS의 경우 make_vms.com을 사용하십시오.
 
-Questions about zlib should be sent to <zlib@gzip.org>, or to Gilles Vollant
-<info@winimage.com> for the Windows DLL version.  The zlib home page is
-http://zlib.net/ .  Before reporting a problem, please check this site to
-verify that you have the latest version of zlib; otherwise get the latest
-version and check whether the problem still exists or not.
+zlib에 대한 질문은 <zlib@gzip.org> 또는 Windows DLL 버전의 경우 Gilles Vollant <info@winimage.com>에게 보내주십시오. zlib 홈페이지는 http://zlib.net/ 입니다. 문제를 보고하기 전에 이 사이트를 확인하여 최신 버전의 zlib를 사용하고 있는지 확인하십시오. 그렇지 않으면 최신 버전을 받고 문제가 여전히 존재하는지 확인하십시오.
 
-PLEASE read the zlib FAQ http://zlib.net/zlib_faq.html before asking for help.
+도움을 요청하기 전에 zlib FAQ http://zlib.net/zlib_faq.html을 읽어보십시오.
 
-Mark Nelson <markn@ieee.org> wrote an article about zlib for the Jan.  1997
-issue of Dr.  Dobb's Journal; a copy of the article is available at
-http://marknelson.us/1997/01/01/zlib-engine/ .
+Mark Nelson <markn@ieee.org>은 Dr. Dobb's Journal 1997년 1월호에 zlib에 대한 기사를 썼습니다. 기사 사본은 http://marknelson.us/1997/01/01/zlib-engine/ 에서 볼 수 있습니다.
 
-The changes made in version 1.2.7 are documented in the file ChangeLog.
+버전 1.2.7에서 변경된 내용은 ChangeLog 파일에 문서화되어 있습니다.
 
-Unsupported third party contributions are provided in directory contrib/ .
+지원되지 않는 타사 기여는 contrib/ 디렉토리에 제공됩니다.
 
-zlib is available in Java using the java.util.zip package, documented at
-http://java.sun.com/developer/technicalArticles/Programming/compression/ .
+zlib는 java.util.zip 패키지를 사용하여 Java에서 사용할 수 있으며, http://java.sun.com/developer/technicalArticles/Programming/compression/ 에 문서화되어 있습니다.
 
-A Perl interface to zlib written by Paul Marquess <pmqs@cpan.org> is available
-at CPAN (Comprehensive Perl Archive Network) sites, including
-http://search.cpan.org/~pmqs/IO-Compress-Zlib/ .
+Paul Marquess <pmqs@cpan.org>가 작성한 zlib용 Perl 인터페이스는 http://search.cpan.org/~pmqs/IO-Compress-Zlib/ 를 포함한 CPAN(Comprehensive Perl Archive Network) 사이트에서 사용할 수 있습니다.
 
-A Python interface to zlib written by A.M. Kuchling <amk@amk.ca> is
-available in Python 1.5 and later versions, see
-http://docs.python.org/library/zlib.html .
+A.M. Kuchling <amk@amk.ca>가 작성한 zlib용 Python 인터페이스는 Python 1.5 이상 버전에서 사용할 수 있으며, http://docs.python.org/library/zlib.html 을 참조하십시오.
 
-zlib is built into tcl: http://wiki.tcl.tk/4610 .
+zlib는 tcl에 내장되어 있습니다: http://wiki.tcl.tk/4610 .
 
-An experimental package to read and write files in .zip format, written on top
-of zlib by Gilles Vollant <info@winimage.com>, is available in the
-contrib/minizip directory of zlib.
+Gilles Vollant <info@winimage.com>가 zlib 위에 작성한 .zip 형식의 파일을 읽고 쓰는 실험적인 패키지는 zlib의 contrib/minizip 디렉토리에서 사용할 수 있습니다.
 
 
-Notes for some targets:
+일부 대상에 대한 참고 사항:
 
-- For Windows DLL versions, please see win32/DLL_FAQ.txt
+- Windows DLL 버전의 경우 win32/DLL_FAQ.txt를 참조하십시오.
 
-- For 64-bit Irix, deflate.c must be compiled without any optimization. With
-  -O, one libpng test fails. The test works in 32 bit mode (with the -n32
-  compiler flag). The compiler bug has been reported to SGI.
+- 64비트 Irix의 경우 deflate.c는 최적화 없이 컴파일해야 합니다. -O를 사용하면 하나의 libpng 테스트가 실패합니다. 이 테스트는 32비트 모드(-n32 컴파일러 플래그 사용)에서는 작동합니다. 컴파일러 버그는 SGI에 보고되었습니다.
 
-- zlib doesn't work with gcc 2.6.3 on a DEC 3000/300LX under OSF/1 2.1 it works
-  when compiled with cc.
+- zlib는 OSF/1 2.1에서 DEC 3000/300LX의 gcc 2.6.3에서는 작동하지 않으며 cc로 컴파일하면 작동합니다.
 
-- On Digital Unix 4.0D (formely OSF/1) on AlphaServer, the cc option -std1 is
-  necessary to get gzprintf working correctly. This is done by configure.
+- AlphaServer의 Digital Unix 4.0D(이전 OSF/1)에서는 gzprintf가 올바르게 작동하려면 cc 옵션 -std1이 필요합니다. 이는 configure에 의해 수행됩니다.
 
-- zlib doesn't work on HP-UX 9.05 with some versions of /bin/cc. It works with
-  other compilers. Use "make test" to check your compiler.
+- zlib는 일부 버전의 /bin/cc를 사용하는 HP-UX 9.05에서는 작동하지 않습니다. 다른 컴파일러에서는 작동합니다. 컴파일러를 확인하려면 "make test"를 사용하십시오.
 
-- gzdopen is not supported on RISCOS or BEOS.
+- gzdopen은 RISCOS 또는 BEOS에서 지원되지 않습니다.
 
-- For PalmOs, see http://palmzlib.sourceforge.net/
+- PalmOs의 경우 http://palmzlib.sourceforge.net/ 을 참조하십시오.
 
 
-Acknowledgments:
+감사의 말:
 
-  The deflate format used by zlib was defined by Phil Katz.  The deflate and
-  zlib specifications were written by L.  Peter Deutsch.  Thanks to all the
-  people who reported problems and suggested various improvements in zlib; they
-  are too numerous to cite here.
+  zlib에서 사용하는 deflate 형식은 Phil Katz가 정의했습니다. deflate 및 zlib 사양은 L. Peter Deutsch가 작성했습니다. zlib의 문제점을 보고하고 다양한 개선 사항을 제안해 주신 모든 분들께 감사드립니다. 너무 많아서 여기에 모두 언급할 수 없습니다.
 
-Copyright notice:
+저작권 고지:
 
  (C) 1995-2012 Jean-loup Gailly and Mark Adler
 
-  This software is provided 'as-is', without any express or implied
-  warranty.  In no event will the authors be held liable for any damages
-  arising from the use of this software.
+  이 소프트웨어는 어떠한 명시적 또는 묵시적 보증 없이 '있는 그대로' 제공됩니다. 어떠한 경우에도 저자는 이 소프트웨어의 사용으로 인해 발생하는 모든 손해에 대해 책임을 지지 않습니다.
 
-  Permission is granted to anyone to use this software for any purpose,
-  including commercial applications, and to alter it and redistribute it
-  freely, subject to the following restrictions:
+  상업적 응용 프로그램을 포함하여 모든 목적으로 이 소프트웨어를 사용하고 다음 제한 사항에 따라 자유롭게 변경하고 재배포할 수 있는 권한이 모든 사람에게 부여됩니다.
 
-  1. The origin of this software must not be misrepresented; you must not
-     claim that you wrote the original software. If you use this software
-     in a product, an acknowledgment in the product documentation would be
-     appreciated but is not required.
-  2. Altered source versions must be plainly marked as such, and must not be
-     misrepresented as being the original software.
-  3. This notice may not be removed or altered from any source distribution.
+  1. 이 소프트웨어의 출처를 허위로 표시해서는 안 됩니다. 원본 소프트웨어를 작성했다고 주장해서는 안 됩니다. 제품에 이 소프트웨어를 사용하는 경우 제품 설명서에 감사의 말을 표시하는 것은 좋지만 필수는 아닙니다.
+  2. 변경된 소스 버전은 명확하게 표시해야 하며 원본 소프트웨어로 허위 표시해서는 안 됩니다.
+  3. 이 고지는 모든 소스 배포에서 제거하거나 변경할 수 없습니다.
 
   Jean-loup Gailly        Mark Adler
   jloup@gzip.org          madler@alumni.caltech.edu
 
-If you use the zlib library in a product, we would appreciate *not* receiving
-lengthy legal documents to sign.  The sources are provided for free but without
-warranty of any kind.  The library has been entirely written by Jean-loup
-Gailly and Mark Adler; it does not include third-party code.
+제품에 zlib 라이브러리를 사용하는 경우 서명해야 할 장황한 법적 문서를 받지 않기를 바랍니다. 소스는 무료로 제공되지만 어떠한 종류의 보증도 없습니다. 이 라이브러리는 Jean-loup Gailly와 Mark Adler가 전적으로 작성했으며 타사 코드를 포함하지 않습니다.
 
-If you redistribute modified sources, we would appreciate that you include in
-the file ChangeLog history information documenting your changes.  Please read
-the FAQ for more information on the distribution of modified source versions.
+수정된 소스를 재배포하는 경우 변경 사항을 문서화하는 ChangeLog 파일 기록 정보를 포함해 주시면 감사하겠습니다. 수정된 소스 버전 배포에 대한 자세한 내용은 FAQ를 읽어보십시오.

--- a/zlib-1.2.7/contrib/minizip/MiniZip64_Changes.txt
+++ b/zlib-1.2.7/contrib/minizip/MiniZip64_Changes.txt
@@ -1,6 +1,4 @@
+MiniZip 1.1은 MiniZip 버전 1.01f에서 파생되었습니다.
 
-MiniZip 1.1 was derrived from MiniZip at version 1.01f
-
-Change in 1.0 (Okt 2009)
- - **TODO - Add history**
-
+1.0 변경 사항 (2009년 10월)
+ - **TODO - 변경 내역 추가**

--- a/zlib-1.2.7/contrib/minizip/MiniZip64_info.txt
+++ b/zlib-1.2.7/contrib/minizip/MiniZip64_info.txt
@@ -1,74 +1,63 @@
-MiniZip - Copyright (c) 1998-2010 - by Gilles Vollant - version 1.1 64 bits from Mathias Svensson
+MiniZip - 저작권 (c) 1998-2010 - Gilles Vollant - Mathias Svensson의 버전 1.1 64비트
 
-Introduction
+소개
 ---------------------
-MiniZip 1.1 is built from MiniZip 1.0 by Gilles Vollant ( http://www.winimage.com/zLibDll/minizip.html )
+MiniZip 1.1은 Gilles Vollant의 MiniZip 1.0 ( http://www.winimage.com/zLibDll/minizip.html )을 기반으로 빌드되었습니다.
 
-When adding ZIP64 support into minizip it would result into risk of breaking compatibility with minizip 1.0.
-All possible work was done for compatibility.
+minizip에 ZIP64 지원을 추가하면 minizip 1.0과의 호환성이 깨질 위험이 있습니다.
+호환성을 위해 가능한 모든 작업이 수행되었습니다.
 
 
-Background
+배경
 ---------------------
-When adding ZIP64 support Mathias Svensson found that Even Rouault have added ZIP64 
-support for unzip.c into minizip for a open source project called gdal ( http://www.gdal.org/ )
+ZIP64 지원을 추가할 때 Mathias Svensson은 Even Rouault가 gdal ( http://www.gdal.org/ )이라는 오픈 소스 프로젝트를 위해 minizip의 unzip.c에 ZIP64 지원을 추가했다는 것을 발견했습니다.
 
-That was used as a starting point. And after that ZIP64 support was added to zip.c
-some refactoring and code cleanup was also done.
+이것이 시작점이 되었고, 그 후 zip.c에 ZIP64 지원이 추가되었으며 일부 리팩토링 및 코드 정리도 수행되었습니다.
 
 
-Changed from MiniZip 1.0 to MiniZip 1.1
+MiniZip 1.0에서 MiniZip 1.1로 변경된 사항
 ---------------------------------------
-* Added ZIP64 support for unzip ( by Even Rouault )
-* Added ZIP64 support for zip ( by Mathias Svensson )
-* Reverted some changed that Even Rouault did.
-* Bunch of patches received from Gulles Vollant that he received for MiniZip from various users.
-* Added unzip patch for BZIP Compression method (patch create by Daniel Borca)
-* Added BZIP Compress method for zip
-* Did some refactoring and code cleanup
+* unzip에 대한 ZIP64 지원 추가 (Even Rouault 제공)
+* zip에 대한 ZIP64 지원 추가 (Mathias Svensson 제공)
+* Even Rouault가 변경한 일부 사항 되돌림
+* Gulles Vollant가 다양한 사용자로부터 MiniZip에 대해 받은 패치 모음
+* BZIP 압축 방식에 대한 unzip 패치 추가 (Daniel Borca가 만든 패치)
+* zip에 대한 BZIP 압축 방식 추가
+* 일부 리팩토링 및 코드 정리 수행
 
 
-Credits
+크레딧
 
- Gilles Vollant    - Original MiniZip author
- Even Rouault      - ZIP64 unzip Support
- Daniel Borca      - BZip Compression method support in unzip
- Mathias Svensson  - ZIP64 zip support
- Mathias Svensson  - BZip Compression method support in zip
+ Gilles Vollant    - 원본 MiniZip 작성자
+ Even Rouault      - ZIP64 unzip 지원
+ Daniel Borca      - unzip의 BZip 압축 방식 지원
+ Mathias Svensson  - ZIP64 zip 지원
+ Mathias Svensson  - zip의 BZip 압축 방식 지원
 
- Resources
+ 리소스
 
  ZipLayout   http://result42.com/projects/ZipFileLayout
-             Command line tool for Windows that shows the layout and information of the headers in a zip archive.
-             Used when debugging and validating the creation of zip files using MiniZip64
+             zip 아카이브의 헤더 레이아웃 및 정보를 보여주는 Windows용 명령줄 도구입니다.
+             MiniZip64를 사용하여 zip 파일 생성을 디버깅하고 검증할 때 사용됩니다.
 
 
  ZIP App Note  http://www.pkware.com/documents/casestudies/APPNOTE.TXT
-               Zip File specification
+               Zip 파일 사양
 
 
-Notes.
- * To be able to use BZip compression method in zip64.c or unzip64.c the BZIP2 lib is needed and HAVE_BZIP2 need to be defined.
+참고.
+ * zip64.c 또는 unzip64.c에서 BZip 압축 방식을 사용하려면 BZIP2 라이브러리가 필요하며 HAVE_BZIP2가 정의되어야 합니다.
 
-License
+라이선스
 ----------------------------------------------------------
-   Condition of use and distribution are the same than zlib :
+   사용 및 배포 조건은 zlib와 동일합니다.
 
-  This software is provided 'as-is', without any express or implied
-  warranty.  In no event will the authors be held liable for any damages
-  arising from the use of this software.
+  이 소프트웨어는 어떠한 명시적 또는 묵시적 보증 없이 '있는 그대로' 제공됩니다. 어떠한 경우에도 저자는 이 소프트웨어의 사용으로 인해 발생하는 모든 손해에 대해 책임을 지지 않습니다.
 
-  Permission is granted to anyone to use this software for any purpose,
-  including commercial applications, and to alter it and redistribute it
-  freely, subject to the following restrictions:
+  상업적 응용 프로그램을 포함하여 모든 목적으로 이 소프트웨어를 사용하고 다음 제한 사항에 따라 자유롭게 변경하고 재배포할 수 있는 권한이 모든 사람에게 부여됩니다.
 
-  1. The origin of this software must not be misrepresented; you must not
-     claim that you wrote the original software. If you use this software
-     in a product, an acknowledgment in the product documentation would be
-     appreciated but is not required.
-  2. Altered source versions must be plainly marked as such, and must not be
-     misrepresented as being the original software.
-  3. This notice may not be removed or altered from any source distribution.
+  1. 이 소프트웨어의 출처를 허위로 표시해서는 안 됩니다. 원본 소프트웨어를 작성했다고 주장해서는 안 됩니다. 제품에 이 소프트웨어를 사용하는 경우 제품 설명서에 감사의 말을 표시하는 것은 좋지만 필수는 아닙니다.
+  2. 변경된 소스 버전은 명확하게 표시해야 하며 원본 소프트웨어로 허위 표시해서는 안 됩니다.
+  3. 이 고지는 모든 소스 배포에서 제거하거나 변경할 수 없습니다.
 
 ----------------------------------------------------------
-

--- a/zlib-1.2.7/doc/algorithm.txt
+++ b/zlib-1.2.7/doc/algorithm.txt
@@ -1,136 +1,50 @@
-1. Compression algorithm (deflate)
+1. 압축 알고리즘 (deflate)
 
-The deflation algorithm used by gzip (also zip and zlib) is a variation of
-LZ77 (Lempel-Ziv 1977, see reference below). It finds duplicated strings in
-the input data.  The second occurrence of a string is replaced by a
-pointer to the previous string, in the form of a pair (distance,
-length).  Distances are limited to 32K bytes, and lengths are limited
-to 258 bytes. When a string does not occur anywhere in the previous
-32K bytes, it is emitted as a sequence of literal bytes.  (In this
-description, `string' must be taken as an arbitrary sequence of bytes,
-and is not restricted to printable characters.)
+gzip (zip 및 zlib에서도 사용)에서 사용하는 deflation 알고리즘은 LZ77 (Lempel-Ziv 1977, 아래 참조)의 변형입니다. 입력 데이터에서 중복된 문자열을 찾습니다. 문자열의 두 번째 발생은 (거리, 길이) 쌍의 형태로 이전 문자열에 대한 포인터로 대체됩니다. 거리는 32K 바이트로 제한되고 길이는 258 바이트로 제한됩니다. 문자열이 이전 32K 바이트 어디에도 나타나지 않으면 리터럴 바이트 시퀀스로 출력됩니다. (이 설명에서 '문자열'은 임의의 바이트 시퀀스로 간주해야 하며 인쇄 가능한 문자로 제한되지 않습니다.)
 
-Literals or match lengths are compressed with one Huffman tree, and
-match distances are compressed with another tree. The trees are stored
-in a compact form at the start of each block. The blocks can have any
-size (except that the compressed data for one block must fit in
-available memory). A block is terminated when deflate() determines that
-it would be useful to start another block with fresh trees. (This is
-somewhat similar to the behavior of LZW-based _compress_.)
+리터럴 또는 일치 길이는 하나의 허프만 트리로 압축되고 일치 거리는 다른 트리로 압축됩니다. 트리는 각 블록의 시작 부분에 간결한 형태로 저장됩니다. 블록은 모든 크기를 가질 수 있습니다 (단, 한 블록에 대한 압축 데이터는 사용 가능한 메모리에 맞아야 함). deflate()가 새 트리로 다른 블록을 시작하는 것이 유용하다고 판단하면 블록이 종료됩니다. (이는 LZW 기반 _compress_의 동작과 다소 유사합니다.)
 
-Duplicated strings are found using a hash table. All input strings of
-length 3 are inserted in the hash table. A hash index is computed for
-the next 3 bytes. If the hash chain for this index is not empty, all
-strings in the chain are compared with the current input string, and
-the longest match is selected.
+중복된 문자열은 해시 테이블을 사용하여 찾습니다. 길이 3의 모든 입력 문자열은 해시 테이블에 삽입됩니다. 다음 3바이트에 대한 해시 인덱스가 계산됩니다. 이 인덱스에 대한 해시 체인이 비어 있지 않으면 체인의 모든 문자열이 현재 입력 문자열과 비교되고 가장 긴 일치가 선택됩니다.
 
-The hash chains are searched starting with the most recent strings, to
-favor small distances and thus take advantage of the Huffman encoding.
-The hash chains are singly linked. There are no deletions from the
-hash chains, the algorithm simply discards matches that are too old.
+해시 체인은 가장 최근 문자열부터 검색되어 작은 거리를 선호하고 따라서 허프만 인코딩을 활용합니다. 해시 체인은 단일 연결됩니다. 해시 체인에서 삭제는 없으며 알고리즘은 단순히 너무 오래된 일치를 버립니다.
 
-To avoid a worst-case situation, very long hash chains are arbitrarily
-truncated at a certain length, determined by a runtime option (level
-parameter of deflateInit). So deflate() does not always find the longest
-possible match but generally finds a match which is long enough.
+최악의 경우를 피하기 위해 매우 긴 해시 체인은 런타임 옵션(deflateInit의 수준 매개변수)에 의해 결정되는 특정 길이에서 임의로 잘립니다. 따라서 deflate()는 항상 가능한 가장 긴 일치를 찾는 것은 아니지만 일반적으로 충분히 긴 일치를 찾습니다.
 
-deflate() also defers the selection of matches with a lazy evaluation
-mechanism. After a match of length N has been found, deflate() searches for
-a longer match at the next input byte. If a longer match is found, the
-previous match is truncated to a length of one (thus producing a single
-literal byte) and the process of lazy evaluation begins again. Otherwise,
-the original match is kept, and the next match search is attempted only N
-steps later.
+deflate()는 또한 지연 평가 메커니즘을 사용하여 일치 선택을 지연시킵니다. 길이 N의 일치가 발견된 후 deflate()는 다음 입력 바이트에서 더 긴 일치를 검색합니다. 더 긴 일치가 발견되면 이전 일치는 길이 1로 잘리고(따라서 단일 리터럴 바이트 생성) 지연 평가 프로세스가 다시 시작됩니다. 그렇지 않으면 원래 일치가 유지되고 다음 일치 검색은 N 단계 후에만 시도됩니다.
 
-The lazy match evaluation is also subject to a runtime parameter. If
-the current match is long enough, deflate() reduces the search for a longer
-match, thus speeding up the whole process. If compression ratio is more
-important than speed, deflate() attempts a complete second search even if
-the first match is already long enough.
+지연 일치 평가는 런타임 매개변수의 영향을 받기도 합니다. 현재 일치가 충분히 길면 deflate()는 더 긴 일치 검색을 줄여 전체 프로세스 속도를 높입니다. 속도보다 압축률이 더 중요한 경우 deflate()는 첫 번째 일치가 이미 충분히 길더라도 전체 두 번째 검색을 시도합니다.
 
-The lazy match evaluation is not performed for the fastest compression
-modes (level parameter 1 to 3). For these fast modes, new strings
-are inserted in the hash table only when no match was found, or
-when the match is not too long. This degrades the compression ratio
-but saves time since there are both fewer insertions and fewer searches.
+지연 일치 평가는 가장 빠른 압축 모드(수준 매개변수 1~3)에서는 수행되지 않습니다. 이러한 빠른 모드의 경우 새 문자열은 일치가 발견되지 않았거나 일치가 너무 길지 않은 경우에만 해시 테이블에 삽입됩니다. 이렇게 하면 압축률이 저하되지만 삽입 및 검색 횟수가 모두 줄어들어 시간이 절약됩니다.
 
 
-2. Decompression algorithm (inflate)
+2. 압축 해제 알고리즘 (inflate)
 
-2.1 Introduction
+2.1 소개
 
-The key question is how to represent a Huffman code (or any prefix code) so
-that you can decode fast.  The most important characteristic is that shorter
-codes are much more common than longer codes, so pay attention to decoding the
-short codes fast, and let the long codes take longer to decode.
+핵심 질문은 허프만 코드(또는 모든 접두사 코드)를 빠르게 디코딩할 수 있도록 표현하는 방법입니다. 가장 중요한 특징은 짧은 코드가 긴 코드보다 훨씬 더 일반적이므로 짧은 코드를 빠르게 디코딩하는 데 주의를 기울이고 긴 코드는 디코딩하는 데 더 오래 걸리도록 하는 것입니다.
 
-inflate() sets up a first level table that covers some number of bits of
-input less than the length of longest code.  It gets that many bits from the
-stream, and looks it up in the table.  The table will tell if the next
-code is that many bits or less and how many, and if it is, it will tell
-the value, else it will point to the next level table for which inflate()
-grabs more bits and tries to decode a longer code.
+inflate()는 가장 긴 코드의 길이보다 작은 입력 비트 수를 포함하는 첫 번째 수준 테이블을 설정합니다. 스트림에서 해당 비트 수를 가져와 테이블에서 조회합니다. 테이블은 다음 코드가 해당 비트 수 이하인지 여부와 개수를 알려주고, 그렇다면 값을 알려줍니다. 그렇지 않으면 inflate()가 더 많은 비트를 가져와 더 긴 코드를 디코딩하려고 시도하는 다음 수준 테이블을 가리킵니다.
 
-How many bits to make the first lookup is a tradeoff between the time it
-takes to decode and the time it takes to build the table.  If building the
-table took no time (and if you had infinite memory), then there would only
-be a first level table to cover all the way to the longest code.  However,
-building the table ends up taking a lot longer for more bits since short
-codes are replicated many times in such a table.  What inflate() does is
-simply to make the number of bits in the first table a variable, and  then
-to set that variable for the maximum speed.
+첫 번째 조회를 수행할 비트 수는 디코딩하는 데 걸리는 시간과 테이블을 빌드하는 데 걸리는 시간 사이의 절충안입니다. 테이블을 빌드하는 데 시간이 걸리지 않고 (무한한 메모리가 있다면) 가장 긴 코드까지 모두 포함하는 첫 번째 수준 테이블만 있을 것입니다. 그러나 짧은 코드가 이러한 테이블에 여러 번 복제되므로 더 많은 비트에 대해 테이블을 빌드하는 데 훨씬 더 많은 시간이 걸립니다. inflate()가 하는 일은 단순히 첫 번째 테이블의 비트 수를 변수로 만들고 해당 변수를 최대 속도로 설정하는 것입니다.
 
-For inflate, which has 286 possible codes for the literal/length tree, the size
-of the first table is nine bits.  Also the distance trees have 30 possible
-values, and the size of the first table is six bits.  Note that for each of
-those cases, the table ended up one bit longer than the ``average'' code
-length, i.e. the code length of an approximately flat code which would be a
-little more than eight bits for 286 symbols and a little less than five bits
-for 30 symbols.
+리터럴/길이 트리에 대해 286개의 가능한 코드가 있는 inflate의 경우 첫 번째 테이블의 크기는 9비트입니다. 또한 거리 트리에는 30개의 가능한 값이 있으며 첫 번째 테이블의 크기는 6비트입니다. 각 경우에 대해 테이블은 "평균" 코드 길이보다 1비트 더 길게 끝났습니다. 즉, 286개 기호에 대해 약 8비트보다 약간 더 길고 30개 기호에 대해 약 5비트보다 약간 짧은 대략적으로 평평한 코드의 코드 길이입니다.
 
 
-2.2 More details on the inflate table lookup
+2.2 inflate 테이블 조회에 대한 자세한 내용
 
-Ok, you want to know what this cleverly obfuscated inflate tree actually
-looks like.  You are correct that it's not a Huffman tree.  It is simply a
-lookup table for the first, let's say, nine bits of a Huffman symbol.  The
-symbol could be as short as one bit or as long as 15 bits.  If a particular
-symbol is shorter than nine bits, then that symbol's translation is duplicated
-in all those entries that start with that symbol's bits.  For example, if the
-symbol is four bits, then it's duplicated 32 times in a nine-bit table.  If a
-symbol is nine bits long, it appears in the table once.
+좋습니다. 이 교묘하게 난독화된 inflate 트리가 실제로 어떻게 생겼는지 알고 싶으시군요. 허프만 트리가 아니라는 것은 맞습니다. 단순히 허프만 기호의 처음, 예를 들어 9비트에 대한 조회 테이블입니다. 기호는 1비트만큼 짧거나 15비트만큼 길 수 있습니다. 특정 기호가 9비트보다 짧으면 해당 기호의 변환은 해당 기호의 비트로 시작하는 모든 항목에 복제됩니다. 예를 들어 기호가 4비트이면 9비트 테이블에 32번 복제됩니다. 기호가 9비트 길이면 테이블에 한 번 나타납니다.
 
-If the symbol is longer than nine bits, then that entry in the table points
-to another similar table for the remaining bits.  Again, there are duplicated
-entries as needed.  The idea is that most of the time the symbol will be short
-and there will only be one table look up.  (That's whole idea behind data
-compression in the first place.)  For the less frequent long symbols, there
-will be two lookups.  If you had a compression method with really long
-symbols, you could have as many levels of lookups as is efficient.  For
-inflate, two is enough.
+기호가 9비트보다 길면 테이블의 해당 항목은 나머지 비트에 대한 다른 유사한 테이블을 가리킵니다. 다시 말하지만, 필요에 따라 중복된 항목이 있습니다. 아이디어는 대부분의 경우 기호가 짧고 테이블 조회가 한 번만 있다는 것입니다. (이것이 애초에 데이터 압축의 전체 아이디어입니다.) 덜 일반적인 긴 기호의 경우 두 번의 조회가 있습니다. 정말 긴 기호가 있는 압축 방법이 있다면 효율적인 만큼 많은 수준의 조회를 가질 수 있습니다. inflate의 경우 두 번이면 충분합니다.
 
-So a table entry either points to another table (in which case nine bits in
-the above example are gobbled), or it contains the translation for the symbol
-and the number of bits to gobble.  Then you start again with the next
-ungobbled bit.
+따라서 테이블 항목은 다른 테이블을 가리키거나(이 경우 위의 예에서 9비트가 사용됨) 기호에 대한 변환과 사용할 비트 수를 포함합니다. 그런 다음 사용되지 않은 다음 비트부터 다시 시작합니다.
 
-You may wonder: why not just have one lookup table for how ever many bits the
-longest symbol is?  The reason is that if you do that, you end up spending
-more time filling in duplicate symbol entries than you do actually decoding.
-At least for deflate's output that generates new trees every several 10's of
-kbytes.  You can imagine that filling in a 2^15 entry table for a 15-bit code
-would take too long if you're only decoding several thousand symbols.  At the
-other extreme, you could make a new table for every bit in the code.  In fact,
-that's essentially a Huffman tree.  But then you spend too much time
-traversing the tree while decoding, even for short symbols.
+가장 긴 기호가 몇 비트이든 상관없이 하나의 조회 테이블만 있으면 되지 않을까 궁금할 수 있습니다. 그 이유는 그렇게 하면 실제로 디코딩하는 것보다 중복된 기호 항목을 채우는 데 더 많은 시간을 소비하기 때문입니다. 적어도 몇만 바이트마다 새 트리를 생성하는 deflate의 출력에 대해서는 그렇습니다. 15비트 코드에 대해 2^15 항목 테이블을 채우는 것은 몇천 개의 기호만 디코딩하는 경우 너무 오래 걸릴 수 있습니다. 다른 극단적인 경우 코드의 모든 비트에 대해 새 테이블을 만들 수 있습니다. 사실, 그것은 본질적으로 허프만 트리입니다. 그러나 짧은 기호에 대해서도 디코딩하는 동안 트리를 순회하는 데 너무 많은 시간을 소비합니다.
 
-So the number of bits for the first lookup table is a trade of the time to
-fill out the table vs. the time spent looking at the second level and above of
-the table.
+따라서 첫 번째 조회 테이블의 비트 수는 테이블을 채우는 시간과 테이블의 두 번째 수준 이상을 보는 데 걸리는 시간 사이의 절충안입니다.
 
-Here is an example, scaled down:
+다음은 축소된 예입니다.
 
-The code being decoded, with 10 symbols, from 1 to 6 bits long:
+디코딩되는 코드, 10개 기호, 1~6비트 길이:
 
 A: 0
 B: 10
@@ -143,7 +57,7 @@ H: 11110
 I: 111110
 J: 111111
 
-Let's make the first table three bits long (eight entries):
+첫 번째 테이블을 3비트 길이(8개 항목)로 만들어 보겠습니다.
 
 000: A,1
 001: A,1
@@ -151,23 +65,19 @@ Let's make the first table three bits long (eight entries):
 011: A,1
 100: B,2
 101: B,2
-110: -> table X (gobble 3 bits)
-111: -> table Y (gobble 3 bits)
+110: -> 테이블 X (3비트 사용)
+111: -> 테이블 Y (3비트 사용)
 
-Each entry is what the bits decode as and how many bits that is, i.e. how
-many bits to gobble.  Or the entry points to another table, with the number of
-bits to gobble implicit in the size of the table.
+각 항목은 비트가 디코딩되는 방식과 해당 비트 수, 즉 사용할 비트 수입니다. 또는 항목은 다른 테이블을 가리키며, 사용할 비트 수는 테이블 크기에 암시적으로 포함됩니다.
 
-Table X is two bits long since the longest code starting with 110 is five bits
-long:
+110으로 시작하는 가장 긴 코드가 5비트 길이이므로 테이블 X는 2비트 길이입니다.
 
 00: C,1
 01: C,1
 10: D,2
 11: E,2
 
-Table Y is three bits long since the longest code starting with 111 is six
-bits long:
+111로 시작하는 가장 긴 코드가 6비트 길이이므로 테이블 Y는 3비트 길이입니다.
 
 000: F,2
 001: F,2
@@ -178,32 +88,19 @@ bits long:
 110: I,3
 111: J,3
 
-So what we have here are three tables with a total of 20 entries that had to
-be constructed.  That's compared to 64 entries for a single table.  Or
-compared to 16 entries for a Huffman tree (six two entry tables and one four
-entry table).  Assuming that the code ideally represents the probability of
-the symbols, it takes on the average 1.25 lookups per symbol.  That's compared
-to one lookup for the single table, or 1.66 lookups per symbol for the
-Huffman tree.
+따라서 여기에는 총 20개의 항목이 있는 세 개의 테이블이 있으며, 이는 구성해야 했습니다. 이는 단일 테이블의 64개 항목과 비교됩니다. 또는 허프만 트리의 16개 항목(6개의 2개 항목 테이블과 1개의 4개 항목 테이블)과 비교됩니다. 코드가 기호의 확률을 이상적으로 나타낸다고 가정하면 기호당 평균 1.25번의 조회가 필요합니다. 이는 단일 테이블의 경우 1번의 조회, 허프만 트리의 경우 기호당 1.66번의 조회와 비교됩니다.
 
-There, I think that gives you a picture of what's going on.  For inflate, the
-meaning of a particular symbol is often more than just a letter.  It can be a
-byte (a "literal"), or it can be either a length or a distance which
-indicates a base value and a number of bits to fetch after the code that is
-added to the base value.  Or it might be the special end-of-block code.  The
-data structures created in inftrees.c try to encode all that information
-compactly in the tables.
+이제 상황이 어떻게 돌아가는지 알 수 있을 것입니다. inflate의 경우 특정 기호의 의미는 종종 단순한 문자 이상입니다. 바이트("리터럴")일 수도 있고, 기본값과 코드 뒤에 가져올 비트 수를 나타내는 길이 또는 거리일 수도 있으며, 이 비트 수는 기본값에 추가됩니다. 또는 특수 블록 끝 코드일 수도 있습니다. inftrees.c에서 생성된 데이터 구조는 테이블에 모든 정보를 간결하게 인코딩하려고 시도합니다.
 
 
 Jean-loup Gailly        Mark Adler
 jloup@gzip.org          madler@alumni.caltech.edu
 
 
-References:
+참고 문헌:
 
 [LZ77] Ziv J., Lempel A., ``A Universal Algorithm for Sequential Data
 Compression,'' IEEE Transactions on Information Theory, Vol. 23, No. 3,
 pp. 337-343.
 
-``DEFLATE Compressed Data Format Specification'' available in
-http://tools.ietf.org/html/rfc1951
+``DEFLATE Compressed Data Format Specification''은 http://tools.ietf.org/html/rfc1951에서 볼 수 있습니다.

--- a/zlib-1.2.7/examples/README.examples
+++ b/zlib-1.2.7/examples/README.examples
@@ -1,49 +1,44 @@
-This directory contains examples of the use of zlib and other relevant
-programs and documentation.
+이 디렉토리에는 zlib 사용 예제 및 기타 관련 프로그램과 문서가 포함되어 있습니다.
 
 enough.c
-    calculation and justification of ENOUGH parameter in inftrees.h
-    - calculates the maximum table space used in inflate tree
-      construction over all possible Huffman codes
+    inftrees.h의 ENOUGH 매개변수 계산 및 근거
+    - 가능한 모든 허프만 코드에 대해 inflate 트리 구성에 사용되는 최대 테이블 공간 계산
 
 fitblk.c
-    compress just enough input to nearly fill a requested output size
-    - zlib isn't designed to do this, but fitblk does it anyway
+    요청된 출력 크기를 거의 채울 만큼만 입력 압축
+    - zlib는 이를 위해 설계되지 않았지만 fitblk는 어쨌든 수행합니다.
 
 gun.c
-    uncompress a gzip file
-    - illustrates the use of inflateBack() for high speed file-to-file
-      decompression using call-back functions
-    - is approximately twice as fast as gzip -d
-    - also provides Unix uncompress functionality, again twice as fast
+    gzip 파일 압축 해제
+    - 콜백 함수를 사용하여 고속 파일 대 파일 압축 해제를 위한 inflateBack() 사용 설명
+    - gzip -d보다 약 2배 빠름
+    - 또한 Unix uncompress 기능을 제공하며, 다시 약 2배 빠름
 
 gzappend.c
-    append to a gzip file
-    - illustrates the use of the Z_BLOCK flush parameter for inflate()
-    - illustrates the use of deflatePrime() to start at any bit
+    gzip 파일에 추가
+    - inflate()에 대한 Z_BLOCK 플러시 매개변수 사용 설명
+    - 모든 비트에서 시작하기 위한 deflatePrime() 사용 설명
 
 gzjoin.c
-    join gzip files without recalculating the crc or recompressing
-    - illustrates the use of the Z_BLOCK flush parameter for inflate()
-    - illustrates the use of crc32_combine()
+    crc를 다시 계산하거나 다시 압축하지 않고 gzip 파일 결합
+    - inflate()에 대한 Z_BLOCK 플러시 매개변수 사용 설명
+    - crc32_combine() 사용 설명
 
 gzlog.c
 gzlog.h
-    efficiently and robustly maintain a message log file in gzip format
-    - illustrates use of raw deflate, Z_PARTIAL_FLUSH, deflatePrime(),
-      and deflateSetDictionary()
-    - illustrates use of a gzip header extra field
+    gzip 형식으로 메시지 로그 파일을 효율적이고 강력하게 유지 관리
+    - 원시 deflate, Z_PARTIAL_FLUSH, deflatePrime() 및 deflateSetDictionary() 사용 설명
+    - gzip 헤더 추가 필드 사용 설명
 
 zlib_how.html
-    painfully comprehensive description of zpipe.c (see below)
-    - describes in excruciating detail the use of deflate() and inflate()
+    zpipe.c(아래 참조)에 대한 매우 포괄적인 설명
+    - deflate() 및 inflate() 사용을 매우 자세하게 설명
 
 zpipe.c
-    reads and writes zlib streams from stdin to stdout
-    - illustrates the proper use of deflate() and inflate()
-    - deeply commented in zlib_how.html (see above)
+    stdin에서 stdout으로 zlib 스트림 읽기 및 쓰기
+    - deflate() 및 inflate()의 올바른 사용 설명
+    - zlib_how.html(위 참조)에 자세히 주석 처리됨
 
 zran.c
-    index a zlib or gzip stream and randomly access it
-    - illustrates the use of Z_BLOCK, inflatePrime(), and
-      inflateSetDictionary() to provide random access
+    zlib 또는 gzip 스트림을 인덱싱하고 무작위로 액세스
+    - 무작위 액세스를 제공하기 위한 Z_BLOCK, inflatePrime() 및 inflateSetDictionary() 사용 설명

--- a/zlib-1.2.7/win32/DLL_FAQ.txt
+++ b/zlib-1.2.7/win32/DLL_FAQ.txt
@@ -1,397 +1,173 @@
+ZLIB1.DLL에 대해 자주 묻는 질문
 
-            Frequently Asked Questions about ZLIB1.DLL
 
-
-This document describes the design, the rationale, and the usage
-of the official DLL build of zlib, named ZLIB1.DLL.  If you have
-general questions about zlib, you should see the file "FAQ" found
-in the zlib distribution, or at the following location:
+이 문서는 zlib의 공식 DLL 빌드인 ZLIB1.DLL의 설계, 근거 및 사용법을 설명합니다. zlib에 대한 일반적인 질문이 있는 경우 zlib 배포판에 있는 "FAQ" 파일 또는 다음 위치를 참조하십시오.
   http://www.gzip.org/zlib/zlib_faq.html
 
 
- 1. What is ZLIB1.DLL, and how can I get it?
+ 1. ZLIB1.DLL은 무엇이며 어떻게 구할 수 있습니까?
 
-  - ZLIB1.DLL is the official build of zlib as a DLL.
-    (Please remark the character '1' in the name.)
+  - ZLIB1.DLL은 DLL로서 zlib의 공식 빌드입니다.
+    (이름에 문자 '1'이 있음을 유의하십시오.)
 
-    Pointers to a precompiled ZLIB1.DLL can be found in the zlib
-    web site at:
+    미리 컴파일된 ZLIB1.DLL에 대한 포인터는 다음 zlib 웹 사이트에서 찾을 수 있습니다.
       http://www.zlib.net/
 
-    Applications that link to ZLIB1.DLL can rely on the following
-    specification:
-
-    * The exported symbols are exclusively defined in the source
-      files "zlib.h" and "zlib.def", found in an official zlib
-      source distribution.
-    * The symbols are exported by name, not by ordinal.
-    * The exported names are undecorated.
-    * The calling convention of functions is "C" (CDECL).
-    * The ZLIB1.DLL binary is linked to MSVCRT.DLL.
-
-    The archive in which ZLIB1.DLL is bundled contains compiled
-    test programs that must run with a valid build of ZLIB1.DLL.
-    It is recommended to download the prebuilt DLL from the zlib
-    web site, instead of building it yourself, to avoid potential
-    incompatibilities that could be introduced by your compiler
-    and build settings.  If you do build the DLL yourself, please
-    make sure that it complies with all the above requirements,
-    and it runs with the precompiled test programs, bundled with
-    the original ZLIB1.DLL distribution.
-
-    If, for any reason, you need to build an incompatible DLL,
-    please use a different file name.
-
-
- 2. Why did you change the name of the DLL to ZLIB1.DLL?
-    What happened to the old ZLIB.DLL?
-
-  - The old ZLIB.DLL, built from zlib-1.1.4 or earlier, required
-    compilation settings that were incompatible to those used by
-    a static build.  The DLL settings were supposed to be enabled
-    by defining the macro ZLIB_DLL, before including "zlib.h".
-    Incorrect handling of this macro was silently accepted at
-    build time, resulting in two major problems:
-
-    * ZLIB_DLL was missing from the old makefile.  When building
-      the DLL, not all people added it to the build options.  In
-      consequence, incompatible incarnations of ZLIB.DLL started
-      to circulate around the net.
-
-    * When switching from using the static library to using the
-      DLL, applications had to define the ZLIB_DLL macro and
-      to recompile all the sources that contained calls to zlib
-      functions.  Failure to do so resulted in creating binaries
-      that were unable to run with the official ZLIB.DLL build.
-
-    The only possible solution that we could foresee was to make
-    a binary-incompatible change in the DLL interface, in order to
-    remove the dependency on the ZLIB_DLL macro, and to release
-    the new DLL under a different name.
-
-    We chose the name ZLIB1.DLL, where '1' indicates the major
-    zlib version number.  We hope that we will not have to break
-    the binary compatibility again, at least not as long as the
-    zlib-1.x series will last.
-
-    There is still a ZLIB_DLL macro, that can trigger a more
-    efficient build and use of the DLL, but compatibility no
-    longer dependents on it.
-
-
- 3. Can I build ZLIB.DLL from the new zlib sources, and replace
-    an old ZLIB.DLL, that was built from zlib-1.1.4 or earlier?
-
-  - In principle, you can do it by assigning calling convention
-    keywords to the macros ZEXPORT and ZEXPORTVA.  In practice,
-    it depends on what you mean by "an old ZLIB.DLL", because the
-    old DLL exists in several mutually-incompatible versions.
-    You have to find out first what kind of calling convention is
-    being used in your particular ZLIB.DLL build, and to use the
-    same one in the new build.  If you don't know what this is all
-    about, you might be better off if you would just leave the old
-    DLL intact.
-
-
- 4. Can I compile my application using the new zlib interface, and
-    link it to an old ZLIB.DLL, that was built from zlib-1.1.4 or
-    earlier?
-
-  - The official answer is "no"; the real answer depends again on
-    what kind of ZLIB.DLL you have.  Even if you are lucky, this
-    course of action is unreliable.
-
-    If you rebuild your application and you intend to use a newer
-    version of zlib (post- 1.1.4), it is strongly recommended to
-    link it to the new ZLIB1.DLL.
-
-
- 5. Why are the zlib symbols exported by name, and not by ordinal?
-
-  - Although exporting symbols by ordinal is a little faster, it
-    is risky.  Any single glitch in the maintenance or use of the
-    DEF file that contains the ordinals can result in incompatible
-    builds and frustrating crashes.  Simply put, the benefits of
-    exporting symbols by ordinal do not justify the risks.
-
-    Technically, it should be possible to maintain ordinals in
-    the DEF file, and still export the symbols by name.  Ordinals
-    exist in every DLL, and even if the dynamic linking performed
-    at the DLL startup is searching for names, ordinals serve as
-    hints, for a faster name lookup.  However, if the DEF file
-    contains ordinals, the Microsoft linker automatically builds
-    an implib that will cause the executables linked to it to use
-    those ordinals, and not the names.  It is interesting to
-    notice that the GNU linker for Win32 does not suffer from this
-    problem.
-
-    It is possible to avoid the DEF file if the exported symbols
-    are accompanied by a "__declspec(dllexport)" attribute in the
-    source files.  You can do this in zlib by predefining the
-    ZLIB_DLL macro.
-
-
- 6. I see that the ZLIB1.DLL functions use the "C" (CDECL) calling
-    convention.  Why not use the STDCALL convention?
-    STDCALL is the standard convention in Win32, and I need it in
-    my Visual Basic project!
-
-    (For readability, we use CDECL to refer to the convention
-     triggered by the "__cdecl" keyword, STDCALL to refer to
-     the convention triggered by "__stdcall", and FASTCALL to
-     refer to the convention triggered by "__fastcall".)
-
-  - Most of the native Windows API functions (without varargs) use
-    indeed the WINAPI convention (which translates to STDCALL in
-    Win32), but the standard C functions use CDECL.  If a user
-    application is intrinsically tied to the Windows API (e.g.
-    it calls native Windows API functions such as CreateFile()),
-    sometimes it makes sense to decorate its own functions with
-    WINAPI.  But if ANSI C or POSIX portability is a goal (e.g.
-    it calls standard C functions such as fopen()), it is not a
-    sound decision to request the inclusion of <windows.h>, or to
-    use non-ANSI constructs, for the sole purpose to make the user
-    functions STDCALL-able.
-
-    The functionality offered by zlib is not in the category of
-    "Windows functionality", but is more like "C functionality".
-
-    Technically, STDCALL is not bad; in fact, it is slightly
-    faster than CDECL, and it works with variable-argument
-    functions, just like CDECL.  It is unfortunate that, in spite
-    of using STDCALL in the Windows API, it is not the default
-    convention used by the C compilers that run under Windows.
-    The roots of the problem reside deep inside the unsafety of
-    the K&R-style function prototypes, where the argument types
-    are not specified; but that is another story for another day.
-
-    The remaining fact is that CDECL is the default convention.
-    Even if an explicit convention is hard-coded into the function
-    prototypes inside C headers, problems may appear.  The
-    necessity to expose the convention in users' callbacks is one
-    of these problems.
-
-    The calling convention issues are also important when using
-    zlib in other programming languages.  Some of them, like Ada
-    (GNAT) and Fortran (GNU G77), have C bindings implemented
-    initially on Unix, and relying on the C calling convention.
-    On the other hand, the pre- .NET versions of Microsoft Visual
-    Basic require STDCALL, while Borland Delphi prefers, although
-    it does not require, FASTCALL.
-
-    In fairness to all possible uses of zlib outside the C
-    programming language, we choose the default "C" convention.
-    Anyone interested in different bindings or conventions is
-    encouraged to maintain specialized projects.  The "contrib/"
-    directory from the zlib distribution already holds a couple
-    of foreign bindings, such as Ada, C++, and Delphi.
-
-
- 7. I need a DLL for my Visual Basic project.  What can I do?
-
-  - Define the ZLIB_WINAPI macro before including "zlib.h", when
-    building both the DLL and the user application (except that
-    you don't need to define anything when using the DLL in Visual
-    Basic).  The ZLIB_WINAPI macro will switch on the WINAPI
-    (STDCALL) convention.  The name of this DLL must be different
-    than the official ZLIB1.DLL.
-
-    Gilles Vollant has contributed a build named ZLIBWAPI.DLL,
-    with the ZLIB_WINAPI macro turned on, and with the minizip
-    functionality built in.  For more information, please read
-    the notes inside "contrib/vstudio/readme.txt", found in the
-    zlib distribution.
-
-
- 8. I need to use zlib in my Microsoft .NET project.  What can I
-    do?
-
-  - Henrik Ravn has contributed a .NET wrapper around zlib.  Look
-    into contrib/dotzlib/, inside the zlib distribution.
-
-
- 9. If my application uses ZLIB1.DLL, should I link it to
-    MSVCRT.DLL?  Why?
-
-  - It is not required, but it is recommended to link your
-    application to MSVCRT.DLL, if it uses ZLIB1.DLL.
-
-    The executables (.EXE, .DLL, etc.) that are involved in the
-    same process and are using the C run-time library (i.e. they
-    are calling standard C functions), must link to the same
-    library.  There are several libraries in the Win32 system:
-    CRTDLL.DLL, MSVCRT.DLL, the static C libraries, etc.
-    Since ZLIB1.DLL is linked to MSVCRT.DLL, the executables that
-    depend on it should also be linked to MSVCRT.DLL.
-
-
-10. Why are you saying that ZLIB1.DLL and my application should
-    be linked to the same C run-time (CRT) library?  I linked my
-    application and my DLLs to different C libraries (e.g. my
-    application to a static library, and my DLLs to MSVCRT.DLL),
-    and everything works fine.
-
-  - If a user library invokes only pure Win32 API (accessible via
-    <windows.h> and the related headers), its DLL build will work
-    in any context.  But if this library invokes standard C API,
-    things get more complicated.
-
-    There is a single Win32 library in a Win32 system.  Every
-    function in this library resides in a single DLL module, that
-    is safe to call from anywhere.  On the other hand, there are
-    multiple versions of the C library, and each of them has its
-    own separate internal state.  Standalone executables and user
-    DLLs that call standard C functions must link to a C run-time
-    (CRT) library, be it static or shared (DLL).  Intermixing
-    occurs when an executable (not necessarily standalone) and a
-    DLL are linked to different CRTs, and both are running in the
-    same process.
-
-    Intermixing multiple CRTs is possible, as long as their
-    internal states are kept intact.  The Microsoft Knowledge Base
-    articles KB94248 "HOWTO: Use the C Run-Time" and KB140584
-    "HOWTO: Link with the Correct C Run-Time (CRT) Library"
-    mention the potential problems raised by intermixing.
-
-    If intermixing works for you, it's because your application
-    and DLLs are avoiding the corruption of each of the CRTs'
-    internal states, maybe by careful design, or maybe by fortune.
-
-    Also note that linking ZLIB1.DLL to non-Microsoft CRTs, such
-    as those provided by Borland, raises similar problems.
-
-
-11. Why are you linking ZLIB1.DLL to MSVCRT.DLL?
-
-  - MSVCRT.DLL exists on every Windows 95 with a new service pack
-    installed, or with Microsoft Internet Explorer 4 or later, and
-    on all other Windows 4.x or later (Windows 98, Windows NT 4,
-    or later).  It is freely distributable; if not present in the
-    system, it can be downloaded from Microsoft or from other
-    software provider for free.
-
-    The fact that MSVCRT.DLL does not exist on a virgin Windows 95
-    is not so problematic.  Windows 95 is scarcely found nowadays,
-    Microsoft ended its support a long time ago, and many recent
-    applications from various vendors, including Microsoft, do not
-    even run on it.  Furthermore, no serious user should run
-    Windows 95 without a proper update installed.
-
-
-12. Why are you not linking ZLIB1.DLL to
-    <<my favorite C run-time library>> ?
-
-  - We considered and abandoned the following alternatives:
-
-    * Linking ZLIB1.DLL to a static C library (LIBC.LIB, or
-      LIBCMT.LIB) is not a good option.  People are using the DLL
-      mainly to save disk space.  If you are linking your program
-      to a static C library, you may as well consider linking zlib
-      in statically, too.
-
-    * Linking ZLIB1.DLL to CRTDLL.DLL looks appealing, because
-      CRTDLL.DLL is present on every Win32 installation.
-      Unfortunately, it has a series of problems: it does not
-      work properly with Microsoft's C++ libraries, it does not
-      provide support for 64-bit file offsets, (and so on...),
-      and Microsoft discontinued its support a long time ago.
-
-    * Linking ZLIB1.DLL to MSVCR70.DLL or MSVCR71.DLL, supplied
-      with the Microsoft .NET platform, and Visual C++ 7.0/7.1,
-      raises problems related to the status of ZLIB1.DLL as a
-      system component.  According to the Microsoft Knowledge Base
-      article KB326922 "INFO: Redistribution of the Shared C
-      Runtime Component in Visual C++ .NET", MSVCR70.DLL and
-      MSVCR71.DLL are not supposed to function as system DLLs,
-      because they may clash with MSVCRT.DLL.  Instead, the
-      application's installer is supposed to put these DLLs
-      (if needed) in the application's private directory.
-      If ZLIB1.DLL depends on a non-system runtime, it cannot
-      function as a redistributable system component.
-
-    * Linking ZLIB1.DLL to non-Microsoft runtimes, such as
-      Borland's, or Cygwin's, raises problems related to the
-      reliable presence of these runtimes on Win32 systems.
-      It's easier to let the DLL build of zlib up to the people
-      who distribute these runtimes, and who may proceed as
-      explained in the answer to Question 14.
-
-
-13. If ZLIB1.DLL cannot be linked to MSVCR70.DLL or MSVCR71.DLL,
-    how can I build/use ZLIB1.DLL in Microsoft Visual C++ 7.0
-    (Visual Studio .NET) or newer?
-
-  - Due to the problems explained in the Microsoft Knowledge Base
-    article KB326922 (see the previous answer), the C runtime that
-    comes with the VC7 environment is no longer considered a
-    system component.  That is, it should not be assumed that this
-    runtime exists, or may be installed in a system directory.
-    Since ZLIB1.DLL is supposed to be a system component, it may
-    not depend on a non-system component.
-
-    In order to link ZLIB1.DLL and your application to MSVCRT.DLL
-    in VC7, you need the library of Visual C++ 6.0 or older.  If
-    you don't have this library at hand, it's probably best not to
-    use ZLIB1.DLL.
-
-    We are hoping that, in the future, Microsoft will provide a
-    way to build applications linked to a proper system runtime,
-    from the Visual C++ environment.  Until then, you have a
-    couple of alternatives, such as linking zlib in statically.
-    If your application requires dynamic linking, you may proceed
-    as explained in the answer to Question 14.
-
-
-14. I need to link my own DLL build to a CRT different than
-    MSVCRT.DLL.  What can I do?
-
-  - Feel free to rebuild the DLL from the zlib sources, and link
-    it the way you want.  You should, however, clearly state that
-    your build is unofficial.  You should give it a different file
-    name, and/or install it in a private directory that can be
-    accessed by your application only, and is not visible to the
-    others (i.e. it's neither in the PATH, nor in the SYSTEM or
-    SYSTEM32 directories).  Otherwise, your build may clash with
-    applications that link to the official build.
-
-    For example, in Cygwin, zlib is linked to the Cygwin runtime
-    CYGWIN1.DLL, and it is distributed under the name CYGZ.DLL.
-
-
-15. May I include additional pieces of code that I find useful,
-    link them in ZLIB1.DLL, and export them?
-
-  - No.  A legitimate build of ZLIB1.DLL must not include code
-    that does not originate from the official zlib source code.
-    But you can make your own private DLL build, under a different
-    file name, as suggested in the previous answer.
-
-    For example, zlib is a part of the VCL library, distributed
-    with Borland Delphi and C++ Builder.  The DLL build of VCL
-    is a redistributable file, named VCLxx.DLL.
-
-
-16. May I remove some functionality out of ZLIB1.DLL, by enabling
-    macros like NO_GZCOMPRESS or NO_GZIP at compile time?
-
-  - No.  A legitimate build of ZLIB1.DLL must provide the complete
-    zlib functionality, as implemented in the official zlib source
-    code.  But you can make your own private DLL build, under a
-    different file name, as suggested in the previous answer.
-
-
-17. I made my own ZLIB1.DLL build.  Can I test it for compliance?
-
-  - We prefer that you download the official DLL from the zlib
-    web site.  If you need something peculiar from this DLL, you
-    can send your suggestion to the zlib mailing list.
-
-    However, in case you do rebuild the DLL yourself, you can run
-    it with the test programs found in the DLL distribution.
-    Running these test programs is not a guarantee of compliance,
-    but a failure can imply a detected problem.
+    ZLIB1.DLL에 링크하는 응용 프로그램은 다음 사양을 따를 수 있습니다.
+
+    * 내보낸 기호는 공식 zlib 소스 배포판에 있는 소스 파일 "zlib.h" 및 "zlib.def"에만 정의됩니다.
+    * 기호는 서수가 아닌 이름으로 내보내집니다.
+    * 내보낸 이름은 장식되지 않습니다.
+    * 함수 호출 규칙은 "C"(CDECL)입니다.
+    * ZLIB1.DLL 바이너리는 MSVCRT.DLL에 링크됩니다.
+
+    ZLIB1.DLL이 번들로 제공되는 아카이브에는 유효한 ZLIB1.DLL 빌드로 실행해야 하는 컴파일된 테스트 프로그램이 포함되어 있습니다. 컴파일러 및 빌드 설정으로 인해 발생할 수 있는 잠재적인 비호환성을 피하기 위해 직접 빌드하는 대신 zlib 웹 사이트에서 미리 빌드된 DLL을 다운로드하는 것이 좋습니다. 직접 DLL을 빌드하는 경우 위의 모든 요구 사항을 준수하고 원본 ZLIB1.DLL 배포판과 함께 번들로 제공되는 미리 컴파일된 테스트 프로그램으로 실행되는지 확인하십시오.
+
+    어떤 이유로든 호환되지 않는 DLL을 빌드해야 하는 경우 다른 파일 이름을 사용하십시오.
+
+
+ 2. DLL 이름을 ZLIB1.DLL로 변경한 이유는 무엇입니까?
+    이전 ZLIB.DLL은 어떻게 되었습니까?
+
+  - zlib-1.1.4 이하에서 빌드된 이전 ZLIB.DLL은 정적 빌드에 사용된 것과 호환되지 않는 컴파일 설정이 필요했습니다. DLL 설정은 "zlib.h"를 포함하기 전에 매크로 ZLIB_DLL을 정의하여 활성화해야 했습니다. 이 매크로를 잘못 처리하면 빌드 시 자동으로 수락되어 두 가지 주요 문제가 발생했습니다.
+
+    * 이전 makefile에 ZLIB_DLL이 누락되었습니다. DLL을 빌드할 때 모든 사람이 빌드 옵션에 이를 추가하지는 않았습니다. 결과적으로 호환되지 않는 ZLIB.DLL의 화신이 인터넷에 유포되기 시작했습니다.
+
+    * 정적 라이브러리 사용에서 DLL 사용으로 전환할 때 응용 프로그램은 ZLIB_DLL 매크로를 정의하고 zlib 함수 호출을 포함하는 모든 소스를 다시 컴파일해야 했습니다. 그렇게 하지 않으면 공식 ZLIB.DLL 빌드로 실행할 수 없는 바이너리가 생성되었습니다.
+
+    저희가 예측할 수 있었던 유일한 해결책은 ZLIB_DLL 매cro에 대한 종속성을 제거하고 새 DLL을 다른 이름으로 릴리스하기 위해 DLL 인터페이스에서 바이너리 비호환 변경을 수행하는 것이었습니다.
+
+    저희는 주 zlib 버전 번호를 나타내는 '1'이 있는 ZLIB1.DLL이라는 이름을 선택했습니다. 적어도 zlib-1.x 시리즈가 지속되는 한 바이너리 호환성을 다시 깨뜨리지 않기를 바랍니다.
+
+    DLL의 보다 효율적인 빌드 및 사용을 트리거할 수 있는 ZLIB_DLL 매크로가 여전히 있지만 호환성은 더 이상 이에 의존하지 않습니다.
+
+
+ 3. 새 zlib 소스에서 ZLIB.DLL을 빌드하고 zlib-1.1.4 이하에서 빌드된 이전 ZLIB.DLL을 바꿀 수 있습니까?
+
+  - 원칙적으로 매크로 ZEXPORT 및 ZEXPORTVA에 호출 규칙 키워드를 할당하여 수행할 수 있습니다. 실제로 이는 "이전 ZLIB.DLL"이 무엇을 의미하는지에 따라 달라집니다. 이전 DLL은 여러 상호 호환되지 않는 버전으로 존재하기 때문입니다. 먼저 특정 ZLIB.DLL 빌드에서 어떤 종류의 호출 규칙이 사용되는지 확인하고 새 빌드에서 동일한 규칙을 사용해야 합니다. 이것이 무엇에 관한 것인지 모르는 경우 이전 DLL을 그대로 두는 것이 좋습니다.
+
+
+ 4. 새 zlib 인터페이스를 사용하여 응용 프로그램을 컴파일하고 zlib-1.1.4 이하에서 빌드된 이전 ZLIB.DLL에 링크할 수 있습니까?
+
+  - 공식적인 답변은 "아니요"입니다. 실제 답변은 다시 어떤 종류의 ZLIB.DLL을 가지고 있는지에 따라 달라집니다. 운이 좋더라도 이 조치는 신뢰할 수 없습니다.
+
+    응용 프로그램을 다시 빌드하고 최신 버전의 zlib(1.1.4 이후)를 사용하려는 경우 새 ZLIB1.DLL에 링크하는 것이 좋습니다.
+
+
+ 5. zlib 기호가 서수가 아닌 이름으로 내보내지는 이유는 무엇입니까?
+
+  - 서수로 기호를 내보내는 것이 약간 빠르지만 위험합니다. 서수를 포함하는 DEF 파일의 유지 관리 또는 사용에 단 하나의 결함이라도 있으면 호환되지 않는 빌드와 실망스러운 충돌이 발생할 수 있습니다. 간단히 말해 서수로 기호를 내보내는 이점은 위험을 정당화하지 못합니다.
+
+    기술적으로 DEF 파일에서 서수를 유지 관리하고 여전히 이름으로 기호를 내보내는 것이 가능해야 합니다. 서수는 모든 DLL에 존재하며 DLL 시작 시 수행되는 동적 링크가 이름을 검색하더라도 서수는 더 빠른 이름 조회를 위한 힌트 역할을 합니다. 그러나 DEF 파일에 서수가 포함되어 있으면 Microsoft 링커는 자동으로 실행 파일이 해당 서수를 사용하고 이름을 사용하지 않도록 하는 implib를 빌드합니다. Win32용 GNU 링커는 이 문제로 어려움을 겪지 않는다는 점이 흥미롭습니다.
+
+    내보낸 기호에 소스 파일에 "__declspec(dllexport)" 특성이 있는 경우 DEF 파일을 피할 수 있습니다. ZLIB_DLL 매크로를 미리 정의하여 zlib에서 이 작업을 수행할 수 있습니다.
+
+
+ 6. ZLIB1.DLL 함수가 "C"(CDECL) 호출 규칙을 사용하는 것을 확인했습니다. STDCALL 규칙을 사용하지 않는 이유는 무엇입니까?
+    STDCALL은 Win32의 표준 규칙이며 Visual Basic 프로젝트에 필요합니다!
+
+    (가독성을 위해 "__cdecl" 키워드로 트리거되는 규칙을 CDECL, "__stdcall" 키워드로 트리거되는 규칙을 STDCALL, "__fastcall" 키워드로 트리거되는 규칙을 FASTCALL이라고 합니다.)
+
+  - 대부분의 기본 Windows API 함수(varargs 없음)는 실제로 WINAPI 규칙(Win32에서 STDCALL로 변환됨)을 사용하지만 표준 C 함수는 CDECL을 사용합니다. 사용자 응용 프로그램이 Windows API에 본질적으로 연결되어 있는 경우(예: CreateFile()과 같은 기본 Windows API 함수 호출) 자체 함수를 WINAPI로 장식하는 것이 합리적일 수 있습니다. 그러나 ANSI C 또는 POSIX 이식성이 목표인 경우(예: fopen()과 같은 표준 C 함수 호출) 사용자 함수를 STDCALL 가능하게 만들기 위해 <windows.h>를 포함하거나 비 ANSI 구문을 사용하는 것은 건전한 결정이 아닙니다.
+
+    zlib에서 제공하는 기능은 "Windows 기능" 범주에 속하지 않고 "C 기능"에 더 가깝습니다.
+
+    기술적으로 STDCALL은 나쁘지 않습니다. 실제로 CDECL보다 약간 빠르며 CDECL과 마찬가지로 가변 인수 함수와 함께 작동합니다. Windows API에서 STDCALL을 사용함에도 불구하고 Windows에서 실행되는 C 컴파일러에서 사용하는 기본 규칙이 아니라는 점이 아쉽습니다. 문제의 근원은 인수 유형이 지정되지 않은 K&R 스타일 함수 프로토타입의 불안전성에 깊이 자리 잡고 있지만, 그것은 다른 날의 다른 이야기입니다.
+
+    남은 사실은 CDECL이 기본 규칙이라는 것입니다. C 헤더 내부의 함수 프로토타입에 명시적인 규칙이 하드 코딩되어 있더라도 문제가 발생할 수 있습니다. 사용자 콜백에 규칙을 노출해야 하는 필요성이 이러한 문제 중 하나입니다.
+
+    호출 규칙 문제는 다른 프로그래밍 언어에서 zlib를 사용할 때도 중요합니다. Ada(GNAT) 및 Fortran(GNU G77)과 같은 일부 언어는 처음에 Unix에서 구현되었으며 C 호출 규칙에 의존하는 C 바인딩을 가지고 있습니다. 반면에 Microsoft Visual Basic의 .NET 이전 버전에는 STDCALL이 필요하며 Borland Delphi는 FASTCALL을 선호하지만 필수는 아닙니다.
+
+    C 프로그래밍 언어 외부에서 zlib를 사용할 수 있는 모든 가능성에 공평하게 하기 위해 기본 "C" 규칙을 선택합니다. 다른 바인딩이나 규칙에 관심이 있는 사람은 누구나 전문화된 프로젝트를 유지 관리하는 것이 좋습니다. zlib 배포판의 "contrib/" 디렉토리에는 이미 Ada, C++ 및 Delphi와 같은 몇 가지 외부 바인딩이 있습니다.
+
+
+ 7. Visual Basic 프로젝트에 DLL이 필요합니다. 어떻게 해야 합니까?
+
+  - DLL과 사용자 응용 프로그램을 모두 빌드할 때 "zlib.h"를 포함하기 전에 ZLIB_WINAPI 매크로를 정의하십시오(Visual Basic에서 DLL을 사용할 때는 아무것도 정의할 필요 없음). ZLIB_WINAPI 매크로는 WINAPI(STDCALL) 규칙을 켭니다. 이 DLL의 이름은 공식 ZLIB1.DLL과 달라야 합니다.
+
+    Gilles Vollant는 ZLIB_WINAPI 매크로가 켜져 있고 minizip 기능이 내장된 ZLIBWAPI.DLL이라는 빌드를 기여했습니다. 자세한 내용은 zlib 배포판에 있는 "contrib/vstudio/readme.txt" 내부의 참고 사항을 읽어보십시오.
+
+
+ 8. Microsoft .NET 프로젝트에서 zlib를 사용해야 합니다. 어떻게 해야 합니까?
+
+  - Henrik Ravn이 zlib 주변에 .NET 래퍼를 기여했습니다. zlib 배포판 내부의 contrib/dotzlib/를 살펴보십시오.
+
+
+ 9. 응용 프로그램에서 ZLIB1.DLL을 사용하는 경우 MSVCRT.DLL에 링크해야 합니까? 왜 그렇습니까?
+
+  - 필수는 아니지만 응용 프로그램에서 ZLIB1.DLL을 사용하는 경우 MSVCRT.DLL에 링크하는 것이 좋습니다.
+
+    동일한 프로세스에 관련되어 있고 C 런타임 라이브러리를 사용하는(즉, 표준 C 함수를 호출하는) 실행 파일(.EXE, .DLL 등)은 동일한 라이브러리에 링크해야 합니다. Win32 시스템에는 CRTDLL.DLL, MSVCRT.DLL, 정적 C 라이브러리 등 여러 라이브러리가 있습니다. ZLIB1.DLL은 MSVCRT.DLL에 링크되므로 이에 의존하는 실행 파일도 MSVCRT.DLL에 링크해야 합니다.
+
+
+10. ZLIB1.DLL과 응용 프로그램이 동일한 C 런타임(CRT) 라이브러리에 링크되어야 한다고 말하는 이유는 무엇입니까? 응용 프로그램과 DLL을 다른 C 라이브러리(예: 응용 프로그램은 정적 라이브러리에, DLL은 MSVCRT.DLL에)에 링크했는데 모든 것이 잘 작동합니다.
+
+  - 사용자 라이브러리가 순수 Win32 API(<windows.h> 및 관련 헤더를 통해 액세스 가능)만 호출하는 경우 해당 DLL 빌드는 모든 컨텍스트에서 작동합니다. 그러나 이 라이브러리가 표준 C API를 호출하면 상황이 더 복잡해집니다.
+
+    Win32 시스템에는 단일 Win32 라이브러리가 있습니다. 이 라이브러리의 모든 함수는 어디서나 안전하게 호출할 수 있는 단일 DLL 모듈에 있습니다. 반면에 C 라이브러리에는 여러 버전이 있으며 각 버전에는 자체 내부 상태가 있습니다. 표준 C 함수를 호출하는 독립 실행형 실행 파일 및 사용자 DLL은 정적이든 공유(DLL)이든 C 런타임(CRT) 라이브러리에 링크해야 합니다. 실행 파일(반드시 독립 실행형일 필요는 없음)과 DLL이 다른 CRT에 링크되고 둘 다 동일한 프로세스에서 실행될 때 혼합이 발생합니다.
+
+    여러 CRT를 혼합하는 것은 내부 상태가 손상되지 않는 한 가능합니다. Microsoft 기술 자료 문서 KB94248 "HOWTO: C 런타임 사용" 및 KB140584 "HOWTO: 올바른 C 런타임(CRT) 라이브러리와 링크"에는 혼합으로 인해 발생하는 잠재적인 문제가 언급되어 있습니다.
+
+    혼합이 효과가 있다면 응용 프로그램과 DLL이 신중한 설계 또는 운에 의해 각 CRT의 내부 상태 손상을 피하고 있기 때문입니다.
+
+    또한 ZLIB1.DLL을 Borland에서 제공하는 것과 같은 비 Microsoft CRT에 링크하면 유사한 문제가 발생합니다.
+
+
+11. ZLIB1.DLL을 MSVCRT.DLL에 링크하는 이유는 무엇입니까?
+
+  - MSVCRT.DLL은 새 서비스 팩이 설치된 모든 Windows 95 또는 Microsoft Internet Explorer 4 이상이 설치된 모든 Windows 95 및 기타 모든 Windows 4.x 이상(Windows 98, Windows NT 4 이상)에 존재합니다. 무료로 배포할 수 있으며 시스템에 없는 경우 Microsoft 또는 다른 소프트웨어 공급업체에서 무료로 다운로드할 수 있습니다.
+
+    MSVCRT.DLL이 순정 Windows 95에 존재하지 않는다는 사실은 그다지 문제가 되지 않습니다. Windows 95는 요즘 거의 찾아볼 수 없으며 Microsoft는 오래 전에 지원을 종료했으며 Microsoft를 포함한 다양한 공급업체의 많은 최신 응용 프로그램은 Windows 95에서 실행되지도 않습니다. 또한 심각한 사용자는 적절한 업데이트가 설치되지 않은 Windows 95를 실행해서는 안 됩니다.
+
+
+12. ZLIB1.DLL을 <<내가 가장 좋아하는 C 런타임 라이브러리>>에 링크하지 않는 이유는 무엇입니까?
+
+  - 저희는 다음 대안을 고려하고 포기했습니다.
+
+    * ZLIB1.DLL을 정적 C 라이브러리(LIBC.LIB 또는 LIBCMT.LIB)에 링크하는 것은 좋은 옵션이 아닙니다. 사람들은 주로 디스크 공간을 절약하기 위해 DLL을 사용합니다. 프로그램을 정적 C 라이브러리에 링크하는 경우 zlib도 정적으로 링크하는 것을 고려할 수 있습니다.
+
+    * ZLIB1.DLL을 CRTDLL.DLL에 링크하는 것은 매력적으로 보입니다. CRTDLL.DLL은 모든 Win32 설치에 존재하기 때문입니다. 안타깝게도 Microsoft의 C++ 라이브러리와 제대로 작동하지 않고 64비트 파일 오프셋을 지원하지 않는 등 일련의 문제가 있으며 Microsoft는 오래 전에 지원을 중단했습니다.
+
+    * Microsoft .NET 플랫폼과 함께 제공되는 MSVCR70.DLL 또는 MSVCR71.DLL 및 Visual C++ 7.0/7.1에 ZLIB1.DLL을 링크하면 ZLIB1.DLL의 시스템 구성 요소로서의 상태와 관련된 문제가 발생합니다. Microsoft 기술 자료 문서 KB326922 "정보: Visual C++ .NET의 공유 C 런타임 구성 요소 재배포"에 따르면 MSVCR70.DLL 및 MSVCR71.DLL은 MSVCRT.DLL과 충돌할 수 있으므로 시스템 DLL로 작동하도록 되어 있지 않습니다. 대신 응용 프로그램 설치 프로그램은 이러한 DLL(필요한 경우)을 응용 프로그램의 개인 디렉토리에 넣어야 합니다. ZLIB1.DLL이 비시스템 런타임에 의존하는 경우 재배포 가능한 시스템 구성 요소로 작동할 수 없습니다.
+
+    * Borland 또는 Cygwin과 같은 비 Microsoft 런타임에 ZLIB1.DLL을 링크하면 Win32 시스템에서 이러한 런타임의 안정적인 존재와 관련된 문제가 발생합니다. 이러한 런타임을 배포하고 질문 14의 답변에 설명된 대로 진행할 수 있는 사람들에게 zlib의 DLL 빌드를 맡기는 것이 더 쉽습니다.
+
+
+13. ZLIB1.DLL을 MSVCR70.DLL 또는 MSVCR71.DLL에 링크할 수 없는 경우 Microsoft Visual C++ 7.0(Visual Studio .NET) 이상에서 ZLIB1.DLL을 어떻게 빌드/사용할 수 있습니까?
+
+  - Microsoft 기술 자료 문서 KB326922(이전 답변 참조)에 설명된 문제로 인해 VC7 환경과 함께 제공되는 C 런타임은 더 이상 시스템 구성 요소로 간주되지 않습니다. 즉, 이 런타임이 존재하거나 시스템 디렉토리에 설치될 수 있다고 가정해서는 안 됩니다. ZLIB1.DLL은 시스템 구성 요소여야 하므로 비시스템 구성 요소에 의존해서는 안 됩니다.
+
+    VC7에서 ZLIB1.DLL과 응용 프로그램을 MSVCRT.DLL에 링크하려면 Visual C++ 6.0 이하의 라이브러리가 필요합니다. 이 라이브러리가 없는 경우 ZLIB1.DLL을 사용하지 않는 것이 가장 좋습니다.
+
+    향후 Microsoft가 Visual C++ 환경에서 적절한 시스템 런타임에 링크된 응용 프로그램을 빌드하는 방법을 제공하기를 바랍니다. 그때까지는 zlib를 정적으로 링크하는 등 몇 가지 대안이 있습니다. 응용 프로그램에 동적 링크가 필요한 경우 질문 14의 답변에 설명된 대로 진행할 수 있습니다.
+
+
+14. 자체 DLL 빌드를 MSVCRT.DLL과 다른 CRT에 링크해야 합니다. 어떻게 해야 합니까?
+
+  - zlib 소스에서 DLL을 자유롭게 다시 빌드하고 원하는 대로 링크하십시오. 그러나 빌드가 비공식적임을 명확히 명시해야 합니다. 다른 파일 이름을 지정하거나 응용 프로그램에서만 액세스할 수 있고 다른 사람에게는 보이지 않는 개인 디렉토리(즉, PATH 또는 SYSTEM 또는 SYSTEM32 디렉토리에 없음)에 설치해야 합니다. 그렇지 않으면 빌드가 공식 빌드에 링크하는 응용 프로그램과 충돌할 수 있습니다.
+
+    예를 들어 Cygwin에서 zlib는 Cygwin 런타임 CYGWIN1.DLL에 링크되며 CYGZ.DLL이라는 이름으로 배포됩니다.
+
+
+15. 유용하다고 생각되는 추가 코드 조각을 포함하고 ZLIB1.DLL에 링크하고 내보낼 수 있습니까?
+
+  - 아니요. ZLIB1.DLL의 합법적인 빌드에는 공식 zlib 소스 코드에서 비롯되지 않은 코드가 포함되어서는 안 됩니다. 그러나 이전 답변에서 제안한 대로 다른 파일 이름으로 자체 개인 DLL 빌드를 만들 수 있습니다.
+
+    예를 들어 zlib는 Borland Delphi 및 C++ Builder와 함께 배포되는 VCL 라이브러리의 일부입니다. VCL의 DLL 빌드는 VCLxx.DLL이라는 재배포 가능한 파일입니다.
+
+
+16. 컴파일 시 NO_GZCOMPRESS 또는 NO_GZIP과 같은 매크로를 활성화하여 ZLIB1.DLL에서 일부 기능을 제거할 수 있습니까?
+
+  - 아니요. ZLIB1.DLL의 합법적인 빌드는 공식 zlib 소스 코드에 구현된 완전한 zlib 기능을 제공해야 합니다. 그러나 이전 답변에서 제안한 대로 다른 파일 이름으로 자체 개인 DLL 빌드를 만들 수 있습니다.
+
+
+17. 자체 ZLIB1.DLL 빌드를 만들었습니다. 규정 준수 여부를 테스트할 수 있습니까?
+
+  - zlib 웹 사이트에서 공식 DLL을 다운로드하는 것이 좋습니다. 이 DLL에서 특이한 것이 필요한 경우 zlib 메일링 리스트에 제안을 보낼 수 있습니다.
+
+    그러나 직접 DLL을 다시 빌드하는 경우 DLL 배포판에 있는 테스트 프로그램으로 실행할 수 있습니다. 이러한 테스트 프로그램을 실행하는 것은 규정 준수를 보장하지는 않지만 실패는 감지된 문제를 의미할 수 있습니다.
 
 **
 
-This document is written and maintained by
+이 문서는 다음 사람이 작성하고 유지 관리합니다.
 Cosmin Truta <cosmint@cs.ubbcluj.ro>

--- a/zlib-1.2.7/win32/README-WIN32.txt
+++ b/zlib-1.2.7/win32/README-WIN32.txt
@@ -1,103 +1,73 @@
-ZLIB DATA COMPRESSION LIBRARY
+ZLIB 데이터 압축 라이브러리
 
-zlib 1.2.7 is a general purpose data compression library.  All the code is
-thread safe.  The data format used by the zlib library is described by RFCs
-(Request for Comments) 1950 to 1952 in the files
-http://www.ietf.org/rfc/rfc1950.txt (zlib format), rfc1951.txt (deflate format)
-and rfc1952.txt (gzip format).
+zlib 1.2.7은 범용 데이터 압축 라이브러리입니다. 모든 코드는 스레드로부터 안전합니다. zlib 라이브러리에서 사용하는 데이터 형식은 RFC(Request for Comments) 1950부터 1952까지의 문서에 설명되어 있으며, 해당 파일은 http://www.ietf.org/rfc/rfc1950.txt (zlib 형식), rfc1951.txt (deflate 형식) 및 rfc1952.txt (gzip 형식)에서 확인할 수 있습니다.
 
-All functions of the compression library are documented in the file zlib.h
-(volunteer to write man pages welcome, contact zlib@gzip.org).  Two compiled
-examples are distributed in this package, example and minigzip.  The example_d
-and minigzip_d flavors validate that the zlib1.dll file is working correctly.
+압축 라이브러리의 모든 함수는 zlib.h 파일에 문서화되어 있습니다 (man 페이지 작성 자원봉사자는 zlib@gzip.org로 연락 바랍니다). 이 패키지에는 컴파일된 예제 두 개(example 및 minigzip)가 배포됩니다. example_d 및 minigzip_d 버전은 zlib1.dll 파일이 올바르게 작동하는지 확인합니다.
 
-Questions about zlib should be sent to <zlib@gzip.org>.  The zlib home page
-is http://zlib.net/ .  Before reporting a problem, please check this site to
-verify that you have the latest version of zlib; otherwise get the latest
-version and check whether the problem still exists or not.
+zlib에 대한 질문은 <zlib@gzip.org>로 보내주십시오. zlib 홈페이지는 http://zlib.net/ 입니다. 문제를 보고하기 전에 이 사이트를 확인하여 최신 버전의 zlib를 사용하고 있는지 확인하십시오. 그렇지 않으면 최신 버전을 받고 문제가 여전히 존재하는지 확인하십시오.
 
-PLEASE read DLL_FAQ.txt, and the the zlib FAQ http://zlib.net/zlib_faq.html
-before asking for help.
+도움을 요청하기 전에 DLL_FAQ.txt와 zlib FAQ http://zlib.net/zlib_faq.html을 읽어보십시오.
 
 
-Manifest:
+목록:
 
-The package zlib-1.2.7-win32-x86.zip will contain the following files:
+zlib-1.2.7-win32-x86.zip 패키지에는 다음 파일이 포함됩니다.
 
-  README-WIN32.txt This document
-  ChangeLog        Changes since previous zlib packages
-  DLL_FAQ.txt      Frequently asked questions about zlib1.dll
-  zlib.3.pdf       Documentation of this library in Adobe Acrobat format
+  README-WIN32.txt 이 문서
+  ChangeLog        이전 zlib 패키지 이후 변경 사항
+  DLL_FAQ.txt      zlib1.dll에 대해 자주 묻는 질문
+  zlib.3.pdf       Adobe Acrobat 형식의 이 라이브러리 설명서
 
-  example.exe      A statically-bound example (using zlib.lib, not the dll)
-  example.pdb      Symbolic information for debugging example.exe
+  example.exe      정적으로 바인딩된 예제 (dll이 아닌 zlib.lib 사용)
+  example.pdb      example.exe 디버깅을 위한 기호 정보
 
-  example_d.exe    A zlib1.dll bound example (using zdll.lib)
-  example_d.pdb    Symbolic information for debugging example_d.exe
+  example_d.exe    zlib1.dll에 바인딩된 예제 (zdll.lib 사용)
+  example_d.pdb    example_d.exe 디버깅을 위한 기호 정보
 
-  minigzip.exe     A statically-bound test program (using zlib.lib, not the dll)
-  minigzip.pdb     Symbolic information for debugging minigzip.exe
+  minigzip.exe     정적으로 바인딩된 테스트 프로그램 (dll이 아닌 zlib.lib 사용)
+  minigzip.pdb     minigzip.exe 디버깅을 위한 기호 정보
 
-  minigzip_d.exe   A zlib1.dll bound test program (using zdll.lib)
-  minigzip_d.pdb   Symbolic information for debugging minigzip_d.exe
+  minigzip_d.exe   zlib1.dll에 바인딩된 테스트 프로그램 (zdll.lib 사용)
+  minigzip_d.pdb   minigzip_d.exe 디버깅을 위한 기호 정보
 
-  zlib.h           Install these files into the compilers' INCLUDE path to
-  zconf.h          compile programs which use zlib.lib or zdll.lib
+  zlib.h           zlib.lib 또는 zdll.lib를 사용하는 프로그램을 컴파일하려면
+  zconf.h          이 파일들을 컴파일러의 INCLUDE 경로에 설치하십시오.
 
-  zdll.lib         Install these files into the compilers' LIB path if linking
-  zdll.exp         a compiled program to the zlib1.dll binary
+  zdll.lib         컴파일된 프로그램을 zlib1.dll 바이너리에 링크하는 경우
+  zdll.exp         이 파일들을 컴파일러의 LIB 경로에 설치하십시오.
 
-  zlib.lib         Install these files into the compilers' LIB path to link zlib
-  zlib.pdb         into compiled programs, without zlib1.dll runtime dependency
-                   (zlib.pdb provides debugging info to the compile time linker)
+  zlib.lib         zlib1.dll 런타임 종속성 없이 zlib를 컴파일된 프로그램에
+  zlib.pdb         링크하려면 이 파일들을 컴파일러의 LIB 경로에 설치하십시오.
+                   (zlib.pdb는 컴파일 타임 링커에 디버깅 정보를 제공합니다.)
 
-  zlib1.dll        Install this binary shared library into the system PATH, or
-                   the program's runtime directory (where the .exe resides)
-  zlib1.pdb        Install in the same directory as zlib1.dll, in order to debug
-                   an application crash using WinDbg or similar tools.
+  zlib1.dll        이 바이너리 공유 라이브러리를 시스템 PATH 또는
+                   프로그램의 런타임 디렉토리(.exe가 있는 위치)에 설치하십시오.
+  zlib1.pdb        WinDbg 또는 유사한 도구를 사용하여 응용 프로그램 충돌을 디버깅하려면
+                   zlib1.dll과 동일한 디렉토리에 설치하십시오.
 
-All .pdb files above are entirely optional, but are very useful to a developer
-attempting to diagnose program misbehavior or a crash.  Many additional
-important files for developers can be found in the zlib127.zip source package
-available from http://zlib.net/ - review that package's README file for details.
+위의 모든 .pdb 파일은 전적으로 선택 사항이지만 프로그램 오작동이나 충돌을 진단하려는 개발자에게 매우 유용합니다. 개발자를 위한 더 많은 중요한 파일은 http://zlib.net/에서 제공되는 zlib127.zip 소스 패키지에서 찾을 수 있습니다. 자세한 내용은 해당 패키지의 README 파일을 검토하십시오.
 
 
-Acknowledgments:
+감사의 말:
 
-The deflate format used by zlib was defined by Phil Katz.  The deflate and
-zlib specifications were written by L.  Peter Deutsch.  Thanks to all the
-people who reported problems and suggested various improvements in zlib; they
-are too numerous to cite here.
+zlib에서 사용하는 deflate 형식은 Phil Katz가 정의했습니다. deflate 및 zlib 사양은 L. Peter Deutsch가 작성했습니다. zlib의 문제점을 보고하고 다양한 개선 사항을 제안해 주신 모든 분들께 감사드립니다. 너무 많아서 여기에 모두 언급할 수 없습니다.
 
 
-Copyright notice:
+저작권 고지:
 
   (C) 1995-2012 Jean-loup Gailly and Mark Adler
 
-  This software is provided 'as-is', without any express or implied
-  warranty.  In no event will the authors be held liable for any damages
-  arising from the use of this software.
+  이 소프트웨어는 어떠한 명시적 또는 묵시적 보증 없이 '있는 그대로' 제공됩니다. 어떠한 경우에도 저자는 이 소프트웨어의 사용으로 인해 발생하는 모든 손해에 대해 책임을 지지 않습니다.
 
-  Permission is granted to anyone to use this software for any purpose,
-  including commercial applications, and to alter it and redistribute it
-  freely, subject to the following restrictions:
+  상업적 응용 프로그램을 포함하여 모든 목적으로 이 소프트웨어를 사용하고 다음 제한 사항에 따라 자유롭게 변경하고 재배포할 수 있는 권한이 모든 사람에게 부여됩니다.
 
-  1. The origin of this software must not be misrepresented; you must not
-     claim that you wrote the original software. If you use this software
-     in a product, an acknowledgment in the product documentation would be
-     appreciated but is not required.
-  2. Altered source versions must be plainly marked as such, and must not be
-     misrepresented as being the original software.
-  3. This notice may not be removed or altered from any source distribution.
+  1. 이 소프트웨어의 출처를 허위로 표시해서는 안 됩니다. 원본 소프트웨어를 작성했다고 주장해서는 안 됩니다. 제품에 이 소프트웨어를 사용하는 경우 제품 설명서에 감사의 말을 표시하는 것은 좋지만 필수는 아닙니다.
+  2. 변경된 소스 버전은 명확하게 표시해야 하며 원본 소프트웨어로 허위 표시해서는 안 됩니다.
+  3. 이 고지는 모든 소스 배포에서 제거하거나 변경할 수 없습니다.
 
   Jean-loup Gailly        Mark Adler
   jloup@gzip.org          madler@alumni.caltech.edu
 
-If you use the zlib library in a product, we would appreciate *not* receiving
-lengthy legal documents to sign.  The sources are provided for free but without
-warranty of any kind.  The library has been entirely written by Jean-loup
-Gailly and Mark Adler; it does not include third-party code.
+제품에 zlib 라이브러리를 사용하는 경우 서명해야 할 장황한 법적 문서를 받지 않기를 바랍니다. 소스는 무료로 제공되지만 어떠한 종류의 보증도 없습니다. 이 라이브러리는 Jean-loup Gailly와 Mark Adler가 전적으로 작성했으며 타사 코드를 포함하지 않습니다.
 
-If you redistribute modified sources, we would appreciate that you include in
-the file ChangeLog history information documenting your changes.  Please read
-the FAQ for more information on the distribution of modified source versions.
+수정된 소스를 재배포하는 경우 변경 사항을 문서화하는 ChangeLog 파일 기록 정보를 포함해 주시면 감사하겠습니다. 수정된 소스 버전 배포에 대한 자세한 내용은 FAQ를 읽어보십시오.


### PR DESCRIPTION
- README.md, CODE_OF_CONDUCT.md, terrace/README.md (오류로 건너뜀), yaml-cpp/README.md, zlib-1.2.7/README 번역
- terraphast/documentation/Changelog.md, terraphast/documentation/Dependencies.md, terraphast/documentation/walkthrough.md (오류로 건너뜀), vectorclass/changelog.txt, yaml-cpp/CONTRIBUTING.md, zlib-1.2.7/FAQ, zlib-1.2.7/contrib/minizip/MiniZip64_Changes.txt, zlib-1.2.7/contrib/minizip/MiniZip64_info.txt, zlib-1.2.7/doc/algorithm.txt, zlib-1.2.7/examples/README.examples, zlib-1.2.7/win32/DLL_FAQ.txt, zlib-1.2.7/win32/README-WIN32.txt 번역